### PR TITLE
Snapshot building unification

### DIFF
--- a/diffkemp/building/CMakeLists.txt
+++ b/diffkemp/building/CMakeLists.txt
@@ -20,9 +20,13 @@ if (NOT DEFINED ENV{WITHOUT_RPYTHON})
   else ()
     set(CC_WRAPPER "${CMAKE_BINARY_DIR}/cc_wrapper-c")
     add_custom_target(cc-wrapper ALL DEPENDS ${CC_WRAPPER})
+    # Note: Setting PYTHONPATH to be able to use diffkemp modules
+    # and also external modules (in case we decide to use them) from the wrapper.
+    set(PYTHONPATH "$ENV{PYTHONPATH}")
     add_custom_command(OUTPUT ${CC_WRAPPER}
                        DEPENDS ${CC_WRAPPER_SOURCE}
-                       COMMAND ${RPYTHON} ${CC_WRAPPER_SOURCE} "--output=${CC_WRAPPER}"
+                       COMMAND "PYTHONPATH=${CMAKE_SOURCE_DIR}:${PYTHONPATH}"
+                         ${RPYTHON} ${CC_WRAPPER_SOURCE} "--output=${CC_WRAPPER}"
                        WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
     install(PROGRAMS ${CC_WRAPPER} RENAME diffkemp-cc-wrapper DESTINATION ${CMAKE_INSTALL_BINDIR})
   endif ()

--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -47,6 +47,9 @@ def make_argument_parser():
     build_ap.add_argument("--no-native-cc-wrapper",
                           help="do not use a native compiler wrapper even if\
                           present", action="store_true")
+    build_ap.add_argument("--no-opt-override",
+                          help="use project's default optimization options",
+                          action="store_true")
     build_ap.set_defaults(func=diffkemp.diffkemp.build)
 
     # "build-kernel" sub-command

--- a/diffkemp/llvm_ir/compiler.py
+++ b/diffkemp/llvm_ir/compiler.py
@@ -1,10 +1,14 @@
 """
 Functions for compilation of c files to LLVM IR.
+
+This file must be RPython compatible because it is used from cc_wrapper.
 """
 
 
-def get_clang_default_options():
-    """Returns clang options for compiling c files to LLVM IR."""
-    return ["-S", "-emit-llvm", "-O1", "-Xclang",
-            "-disable-llvm-passes", "-g", "-fdebug-macro",
-            "-Wno-format-security"]
+def get_clang_default_options(default_optim=True):
+    """Returns clang options for compiling c files to LLVM IR.
+    :param default_optim: By default adds also optimization flags."""
+    opts = ["-S", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"]
+    if default_optim:
+        opts.extend(["-O1", "-Xclang", "-disable-llvm-passes"])
+    return opts

--- a/diffkemp/llvm_ir/compiler.py
+++ b/diffkemp/llvm_ir/compiler.py
@@ -1,0 +1,10 @@
+"""
+Functions for compilation of c files to LLVM IR.
+"""
+
+
+def get_clang_default_options():
+    """Returns clang options for compiling c files to LLVM IR."""
+    return ["-S", "-emit-llvm", "-O1", "-Xclang",
+            "-disable-llvm-passes", "-g", "-fdebug-macro",
+            "-Wno-format-security"]

--- a/diffkemp/llvm_ir/optimiser.py
+++ b/diffkemp/llvm_ir/optimiser.py
@@ -1,0 +1,31 @@
+"""Functions for optimizations of LLVM IR."""
+from diffkemp.utils import get_opt_command
+from subprocess import check_call, CalledProcessError
+import os
+
+
+class BuildException(Exception):
+    pass
+
+
+def opt_llvm(llvm_file):
+    """
+    Optimize LLVM IR using 'opt' tool.
+    Run basic simplification passes and -constmerge to remove
+    duplicate constants that might have come from linked files.
+    """
+    passes = [("lowerswitch", "function"),
+              ("mem2reg", "function"),
+              ("loop-simplify", "function"),
+              ("simplifycfg", "function"),
+              ("gvn", "function"),
+              ("dce", "function"),
+              ("constmerge", "module"),
+              ("mergereturn", "function"),
+              ("simplifycfg", "function")]
+    opt_command = get_opt_command(passes, llvm_file)
+    try:
+        with open(os.devnull, "w") as devnull:
+            check_call(opt_command, stderr=devnull)
+    except CalledProcessError:
+        raise BuildException("Running opt failed")

--- a/diffkemp/llvm_ir/single_c_builder.py
+++ b/diffkemp/llvm_ir/single_c_builder.py
@@ -1,6 +1,8 @@
 """
 LLVM source builder for single C file.
 """
+from diffkemp.llvm_ir.compiler import get_clang_default_options
+from diffkemp.llvm_ir.optimiser import opt_llvm
 from diffkemp.llvm_ir.single_llvm_finder import SingleLlvmFinder
 from diffkemp.utils import get_functions_from_llvm
 import os
@@ -13,10 +15,12 @@ class SingleCBuilder(SingleLlvmFinder):
     Extends the SingleLlvmFinder class by compiling C file to LLVM IR file.
     """
     def __init__(self, source_dir, c_file_name, clang="clang",
-                 clang_append=[]):
+                 clang_append=[], default_optim=True):
         """
         :param clang: clang compiler to be used
         :param clang_append: list of args to add when compiling
+        :param default_optim: use default optimalisations flags
+            and run LLVM IR simplification passes
         """
         llvm_file_name = os.path.splitext(c_file_name)[0] + ".ll"
         SingleLlvmFinder.__init__(self, source_dir, llvm_file_name)
@@ -24,17 +28,26 @@ class SingleCBuilder(SingleLlvmFinder):
         self.c_file_name = c_file_name
         self.clang = clang
         self.clang_append = clang_append
+        self.default_optim = default_optim
         self.initialize()
 
     def str(self):
         return "single_c_file"
 
     def initialize(self):
+        """Compiles the C file to LLVM IR file and runs passes"""
         # Using clang to compile c file to llvm file.
-        command = [self.clang, "-S", "-emit-llvm", "-g", self.c_file_name,
-                   "-o", self.llvm_file_name]
+        command = [self.clang, self.c_file_name, "-o", self.llvm_file_name]
+        # Note: clang uses the last specified optimization level so
+        # extending with the default options must be done before
+        # extending with the clang_append option.
+        command.extend(get_clang_default_options(self.default_optim))
         command.extend(self.clang_append)
         check_call(command, cwd=self.source_dir)
+
+        # Running llvm passes
+        if self.default_optim:
+            opt_llvm(self.llvm_file_path)
 
     def get_function_list(self):
         """Returns a list of functions that are found in the source file."""

--- a/diffkemp/llvm_ir/single_llvm_finder.py
+++ b/diffkemp/llvm_ir/single_llvm_finder.py
@@ -15,6 +15,8 @@ class SingleLlvmFinder(LlvmSourceFinder):
     def __init__(self, source_dir, llvm_file_name):
         LlvmSourceFinder.__init__(self, source_dir)
         self.llvm_file_name = llvm_file_name
+        self.llvm_file_path = os.path.join(self.source_dir,
+                                           self.llvm_file_name)
 
     def str(self):
         return "single_llvm_file"
@@ -29,7 +31,7 @@ class SingleLlvmFinder(LlvmSourceFinder):
         pass
 
     def find_llvm_with_symbol_def(self, symbol):
-        return os.path.join(self.source_dir, self.llvm_file_name)
+        return self.llvm_file_path
 
     def find_llvm_with_symbol_use(self, symbol):
-        return os.path.join(self.source_dir, self.llvm_file_name)
+        return self.llvm_file_path

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,13 @@
             # the function (and all functions it uses) as commands.
             shellHook = ''
               export -f setuptoolsShellHook runHook _eval _callImplicitHook
+
+              # Adding current (diffkemp) directory to PYTHONPATH,
+              # the `diffkemp build` subcommand does not work without it
+              # - `cc_wrapper.py` ends with `ModuleNotFoundError` because
+              # `setuptoolsShellHook` does not make diffkemp package
+              # importable for subprocesses called from python.
+              export PYTHONPATH="$(pwd):$PYTHONPATH"
             '';
           };
     in


### PR DESCRIPTION
DiffKemp contains multiple commands for creating snapshots (`build`, `build-kernel`, `llvm-to-snapshot`), this PR tries to unify  `build` command with `build-kernel` command (as discussed in #287 ). The clang options and LLVM passes are taken from `build-kernel` command, which is taken as the expected default behaviour for `build`.

The `build` command will now by default:
- compile file/project using `-O1 -Xclang -disable-llvm-passes`,
- run selected simplification passes using `opt`.

Using `--clang-drop` does not change the behaviour mentioned above only drops certain flags which are in the Makefile.

Same as before this PR, `--clang_append` can be used to specify other flags which should be added. You can also use it to change the optimization level, but it will still use `-Xclang -disable-llvm-passes` and run the default simplification passes.

By using `--no-opt-override` you can turn off the default behaviour, then the `-O1 -Xclang -disable-llvm-passes` flags are not used and the default simplification passes are not run. For the optimisation level is then used the one which is specified in Makefile or you can change it by `--clang-append`.