### PR TITLE
Viewer - add visualisation of macros and macro-function diffs

### DIFF
--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -209,6 +209,8 @@ class ComparisonGraph:
     class SyntaxDiff(NonFunDiff):
         """
         A syntax difference.
+        :param kind: The kind of difference: 'macro', 'assembly',
+            'function-macro', 'macro-function', ('unknown').
         :param name: Name of an 'object' (eg. macro) in the first module in
             which was found difference. In case of inline assembly difference
             the name starts with "assembly code " followed by a number.
@@ -225,7 +227,9 @@ class ComparisonGraph:
             information about definition (name, file, line) of the differing
             macros, otherwise contains None.
         """
-        def __init__(self, name, parent_fun, callstack, body, last_def=None):
+        def __init__(self, kind, name, parent_fun, callstack, body,
+                     last_def=None):
+            self.kind = kind
             self.name = name
             self.parent_fun = parent_fun
             self.callstack = callstack
@@ -241,6 +245,7 @@ class ComparisonGraph:
                 last_def = (nonfun_diff["last-def-first"],
                             nonfun_diff["last-def-second"])
             return cls(
+                nonfun_diff["kind"],
                 nonfun_diff["name"],
                 nonfun_diff["function"],
                 (nonfun_diff["stack-first"], nonfun_diff["stack-second"]),

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -209,23 +209,43 @@ class ComparisonGraph:
     class SyntaxDiff(NonFunDiff):
         """
         A syntax difference.
-
-        Note: body is a tuple containing the values for both modules.
+        :param name: Name of an 'object' (eg. macro) in the first module in
+            which was found difference. In case of inline assembly difference
+            the name starts with "assembly code " followed by a number.
+        :param parent_fun: Name of vertex in which was the syntax diff found.
+        :param callstack: Tuple (call stack in first module, second one),
+            callstack is dict with keys `file`, `line`, `weak`, `function`.
+            The `function` contains name of called 'object', in case of macro
+            the name contains extension " (macro)".
+            The `line` in this case is line, where the definition starts
+            of the macro from which is called 'object' specified by `function`.
+        :param body: A tuple containing the body of the 'object' for both
+            modules.
+        :param last_def: Tuple (first, second), for macro difference contains
+            information about definition (name, file, line) of the differing
+            macros, otherwise contains None.
         """
-        def __init__(self, name, parent_fun, callstack, body):
+        def __init__(self, name, parent_fun, callstack, body, last_def=None):
             self.name = name
             self.parent_fun = parent_fun
             self.callstack = callstack
             self.body = body
+            self.last_def = last_def
 
         @classmethod
         def from_yaml(cls, nonfun_diff):
             """Generates a SyntaxDiff object from YAML returned by SimpLL."""
+            last_def = None
+            if ("last-def-first" in nonfun_diff and
+                    "last-def-second" in nonfun_diff):
+                last_def = (nonfun_diff["last-def-first"],
+                            nonfun_diff["last-def-second"])
             return cls(
                 nonfun_diff["name"],
                 nonfun_diff["function"],
                 (nonfun_diff["stack-first"], nonfun_diff["stack-second"]),
-                (nonfun_diff["body-first"], nonfun_diff["body-second"])
+                (nonfun_diff["body-first"], nonfun_diff["body-second"]),
+                last_def
             )
 
     class TypeDiff(NonFunDiff):

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -81,6 +81,27 @@ class Result:
                      "line": call["line"]}
                     for call in self.calls]
 
+        @staticmethod
+        def get_name_and_kind(call):
+            """Returns tuple (name, kind) for a call."""
+            name = call["name"]
+            kind = "function"
+            if " " in name:
+                name, kind = name.split(" ")
+                # kind looks like this "(kind)", extracting it from brackets
+                kind = kind[1:-1]
+            return (name, kind)
+
+        def get_parent_call_name(self, index, compared_fun):
+            """Returns name of the parrent call (calling function/macro)-
+            :param index: Index to callstack containing current call.
+            :param compared_fun: Name of compared function.
+            """
+            parent_name = (self.calls[index - 1]["name"]
+                           if index >= 1
+                           else compared_fun)
+            return parent_name
+
         def get_symbol_names(self, compared_fun):
             """
             Returns a tuple containing three sets of symbol names which appear
@@ -89,30 +110,24 @@ class Result:
             - macro names (set of strings)
             - type names (set of string pairs)
                 (type name, name of function in which the type is used)
-
             :param compared_fun: Name of compared function.
             """
             function_names = set()
             macro_names = set()
             type_names = set()
-            if self.calls:
-                for index, call in enumerate(self.calls):
-                    # getting symbol name
-                    name = call["name"]
-                    kind = "function"
-                    if " " in name:
-                        name, kind = name.split(" ")
-                    if kind == "function":
-                        function_names.add(name)
-                    elif kind == "(macro)":
-                        macro_names.add(name)
-                    elif kind == "(type)":
-                        # name of type and name of function
-                        # in which it is used
-                        parent_name = (self.calls[index - 1]["name"]
-                                       if index >= 1
-                                       else compared_fun)
-                        type_names.add((name, parent_name))
+            if not self.calls:
+                return function_names, macro_names, type_names
+            for index, call in enumerate(self.calls):
+                name, kind = self.get_name_and_kind(call)
+                if kind == "function":
+                    function_names.add(name)
+                elif kind == "macro":
+                    macro_names.add(name)
+                elif kind == "type":
+                    # name of type and name of function in which it is used
+                    parent_name = self.get_parent_call_name(index,
+                                                            compared_fun)
+                    type_names.add((name, parent_name))
             return function_names, macro_names, type_names
 
         def __str__(self):

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -67,6 +67,19 @@ template <> struct MappingTraits<FunctionInfo> {
 } // namespace yaml
 } // namespace llvm
 
+// Definition (stored in unique_ptr) to YAML
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<std::unique_ptr<Definition>> {
+    static void mapping(IO &io, std::unique_ptr<Definition> &def) {
+        io.mapRequired("name", def->name);
+        io.mapRequired("file", def->sourceFile);
+        io.mapRequired("line", def->line);
+    }
+};
+} // namespace yaml
+} // namespace llvm
+
 // NonFunctionDifference (stored in unique_ptr) to YAML
 namespace llvm {
 namespace yaml {
@@ -80,6 +93,11 @@ template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
         if (auto syntaxDiff = unique_dyn_cast<SyntaxDifference>(diff)) {
             io.mapOptional("body-first", syntaxDiff->BodyL);
             io.mapOptional("body-second", syntaxDiff->BodyR);
+            if (syntaxDiff->lastDefL && syntaxDiff->lastDefR) {
+                // information about definitions of last 'objects' (macros).
+                io.mapOptional("last-def-first", syntaxDiff->lastDefL);
+                io.mapOptional("last-def-second", syntaxDiff->lastDefR);
+            }
         } else if (auto typeDiff = unique_dyn_cast<TypeDifference>(diff)) {
             io.mapOptional("file-first", typeDiff->FileL);
             io.mapOptional("file-second", typeDiff->FileR);

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -80,6 +80,25 @@ template <> struct MappingTraits<std::unique_ptr<Definition>> {
 } // namespace yaml
 } // namespace llvm
 
+// SyntaxDifference::SyntaxKind to YAML
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<SyntaxDifference::SyntaxKind> {
+    static void enumeration(IO &io, SyntaxDifference::SyntaxKind &kind) {
+        io.enumCase(kind, "macro", SyntaxDifference::SyntaxKind::MACRO);
+        io.enumCase(kind,
+                    "macro-function",
+                    SyntaxDifference::SyntaxKind::MACRO_FUNCTION);
+        io.enumCase(kind,
+                    "function-macro",
+                    SyntaxDifference::SyntaxKind::FUNCTION_MACRO);
+        io.enumCase(kind, "assembly", SyntaxDifference::SyntaxKind::ASSEMBLY);
+        io.enumCase(kind, "unknown", SyntaxDifference::SyntaxKind::UNKNOWN);
+    }
+};
+} // namespace yaml
+} // namespace llvm
+
 // NonFunctionDifference (stored in unique_ptr) to YAML
 namespace llvm {
 namespace yaml {
@@ -91,6 +110,7 @@ template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
         io.mapRequired("stack-second", diff->StackR);
 
         if (auto syntaxDiff = unique_dyn_cast<SyntaxDifference>(diff)) {
+            io.mapOptional("kind", syntaxDiff->syntaxKind);
             io.mapOptional("body-first", syntaxDiff->BodyL);
             io.mapOptional("body-second", syntaxDiff->BodyR);
             if (syntaxDiff->lastDefL && syntaxDiff->lastDefR) {

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -79,6 +79,20 @@ struct FunctionInfo {
     }
 };
 
+/// Type for storing informations about definition of an analysed
+// 'object' (eg. macro).
+struct Definition {
+    // Name of the 'object'.
+    std::string name;
+    // Line in the sourceFile on which is located definition of the 'object'.
+    int line;
+    // A C source file name in which is located the 'object' definition.
+    std::string sourceFile;
+    Definition() = default;
+    Definition(std::string name, int line, std::string sourceFile)
+            : name(name), line(line), sourceFile(sourceFile) {}
+};
+
 /// Generic type for non-function differences.
 struct NonFunctionDifference {
     /// Discriminator for LLVM-style RTTI (dyn_cast<> et al.)

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -120,19 +120,26 @@ struct NonFunctionDifference {
 
 /// Syntactic difference between objects that cannot be found in the original
 /// source files.
-/// Note: this can be either a macro difference or inline assembly difference.
+/// There are multiple kinds of the differences: a macro diff,
+/// inline assembly diff, function-macro diff or macro-function diff.
 struct SyntaxDifference : public NonFunctionDifference {
     /// The difference.
     std::string BodyL, BodyR;
+    // Informations about definitions of last 'object' (macro) in call stack.
+    // For now it is only used in macro differences.
+    std::unique_ptr<Definition> lastDefL, lastDefR;
     SyntaxDifference() : NonFunctionDifference(SynDiff){};
     SyntaxDifference(std::string name,
                      std::string BodyL,
                      std::string BodyR,
                      CallStack StackL,
                      CallStack StackR,
-                     std::string function)
+                     std::string function,
+                     std::unique_ptr<Definition> lastDefL,
+                     std::unique_ptr<Definition> lastDefR)
             : NonFunctionDifference(name, StackL, StackR, function, SynDiff),
-              BodyL(BodyL), BodyR(BodyR) {}
+              BodyL(BodyL), BodyR(BodyR), lastDefL(std::move(lastDefL)),
+              lastDefR(std::move(lastDefR)) {}
     static bool classof(const NonFunctionDifference *Diff) {
         return Diff->getKind() == SynDiff;
     }

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -123,13 +123,23 @@ struct NonFunctionDifference {
 /// There are multiple kinds of the differences: a macro diff,
 /// inline assembly diff, function-macro diff or macro-function diff.
 struct SyntaxDifference : public NonFunctionDifference {
+    enum SyntaxKind {
+        MACRO,
+        ASSEMBLY,
+        FUNCTION_MACRO,
+        MACRO_FUNCTION,
+        UNKNOWN
+    };
+    SyntaxKind syntaxKind;
     /// The difference.
     std::string BodyL, BodyR;
     // Informations about definitions of last 'object' (macro) in call stack.
-    // For now it is only used in macro differences.
+    // For now it is used in macro, function-macro, macro-function differences.
     std::unique_ptr<Definition> lastDefL, lastDefR;
-    SyntaxDifference() : NonFunctionDifference(SynDiff){};
-    SyntaxDifference(std::string name,
+    SyntaxDifference()
+            : NonFunctionDifference(SynDiff), syntaxKind(SyntaxKind::UNKNOWN){};
+    SyntaxDifference(SyntaxKind syntaxKind,
+                     std::string name,
                      std::string BodyL,
                      std::string BodyR,
                      CallStack StackL,
@@ -138,8 +148,8 @@ struct SyntaxDifference : public NonFunctionDifference {
                      std::unique_ptr<Definition> lastDefL,
                      std::unique_ptr<Definition> lastDefR)
             : NonFunctionDifference(name, StackL, StackR, function, SynDiff),
-              BodyL(BodyL), BodyR(BodyR), lastDefL(std::move(lastDefL)),
-              lastDefR(std::move(lastDefR)) {}
+              syntaxKind(syntaxKind), BodyL(BodyL), BodyR(BodyR),
+              lastDefL(std::move(lastDefL)), lastDefR(std::move(lastDefR)) {}
     static bool classof(const NonFunctionDifference *Diff) {
         return Diff->getKind() == SynDiff;
     }

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -298,14 +298,25 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                                               << elem.file << " on line "
                                               << elem.line << "\n");
             };
-
+            // Copying info about last macros definition for the 'user' so he
+            // knows where the difference was found (eg. for showing diff).
+            auto lastDefL = std::make_unique<Definition>(
+                    MacroUseL.second.def->name,
+                    MacroUseL.second.def->line,
+                    MacroUseL.second.def->sourceFile);
+            auto lastDefR = std::make_unique<Definition>(
+                    MacroUseR->second.def->name,
+                    MacroUseR->second.def->line,
+                    MacroUseR->second.def->sourceFile);
             result.push_back(std::make_unique<SyntaxDifference>(
                     MacroUseL.second.def->name,
                     MacroUseL.second.def->body.str(),
                     MacroUseR->second.def->body.str(),
                     StackL,
                     StackR,
-                    L->getFunction()->getName().str()));
+                    L->getFunction()->getName().str(),
+                    std::move(lastDefL),
+                    std::move(lastDefR)));
         }
     }
 

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -309,6 +309,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                     MacroUseR->second.def->line,
                     MacroUseR->second.def->sourceFile);
             result.push_back(std::make_unique<SyntaxDifference>(
+                    SyntaxDifference::SyntaxKind::MACRO,
                     MacroUseL.second.def->name,
                     MacroUseL.second.def->body.str(),
                     MacroUseR->second.def->body.str(),

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -26,19 +26,17 @@
 
 using namespace llvm;
 
-/// Macro definition containing name, body, location, and parameters
-struct MacroDef {
-    // The macro name is shortened, therefore it has to be stored as the whole
-    // string, not as a StringRef (otherwise the content would be dropped after
-    // the block in which the shortening is done).
-    std::string name;
+/// Specialisation of Definition from "Result.h", contains more information
+/// (body, parameters, ...) which are used for finding macro difference.
+struct MacroDef : public Definition {
+    // Note: The macro name is shortened, therefore it has to be stored as the
+    // whole string, not as a StringRef (otherwise the content would be dropped
+    // after the block in which the shortening is done).
+
     // Full macro name (including parameters).
     std::string fullName;
     // The body is in DebugInfo therefore it can be stored by reference.
     StringRef body;
-    // Location of the macro definition in C source.
-    int line;
-    std::string sourceFile;
     // List of the macro parameters.
     std::vector<std::string> params;
 };

--- a/tests/unit_tests/caching_test.py
+++ b/tests/unit_tests/caching_test.py
@@ -169,11 +169,11 @@ def test_graph_to_fun_pair_list(graph):
         graph.graph_to_fun_pair_list("main_function", "main_function", False)
     for side in [0, 1]:
         assert {obj[side].name for obj in objects_to_compare} == {
-            "do_check", "MACRO", "struct_file"}
+            "do_check", "___MACRO", "struct_file"}
         do_check = [obj[side] for obj in objects_to_compare
                     if obj[side].name == "do_check"][0]
         macro = [obj[side] for obj in objects_to_compare
-                 if obj[side].name == "MACRO"][0]
+                 if obj[side].name == "___MACRO"][0]
         struct_file = [obj[side] for obj in objects_to_compare
                        if obj[side].name == "struct_file"][0]
         assert do_check.filename == "app/main.c"
@@ -198,8 +198,8 @@ def test_graph_to_fun_pair_list(graph):
         assert not struct_file.covered
     # All results should be not equal.
     assert {obj[2] for obj in objects_to_compare} == {Result.Kind.NOT_EQUAL}
-    assert syndiff_bodies_left == {"MACRO": "5"}
-    assert syndiff_bodies_right == {"MACRO": "5L"}
+    assert syndiff_bodies_left == {"___MACRO": "5"}
+    assert syndiff_bodies_right == {"___MACRO": "5L"}
 
 
 def test_populate_predecessor_lists(graph):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -39,12 +39,13 @@ def graph():
     )
     # Non-function differences
     g["do_check"].nonfun_diffs.append(ComparisonGraph.SyntaxDiff(
-        "MACRO", "do_check",
+        "macro", "___MACRO", "do_check",
         dup([
             {"function": "_MACRO (macro)", "file": "test.c", "line": 1},
             {"function": "__MACRO (macro)", "file": "test.c", "line": 2},
             {"function": "___MACRO (macro)", "file": "test.c", "line": 3},
-        ]), ("5", "5L")
+        ]), ("5", "5L"),
+        dup({"name": "___MACRO", "file": "test.c", "line": 4})
     ))
     g["do_check"].nonfun_diffs.append(ComparisonGraph.TypeDiff(
         "struct_file", "do_check",

--- a/tests/unit_tests/result_test.py
+++ b/tests/unit_tests/result_test.py
@@ -20,7 +20,7 @@ def test_callstack_from_simpll_yaml(graph):
     """Tests creation of Callstack from representation used in non-fun diffs.
     """
     macro = [nonfun_diff for nonfun_diff in graph["do_check"].nonfun_diffs
-             if nonfun_diff.name == "MACRO"][0]
+             if nonfun_diff.name == "___MACRO"][0]
     callstack = Result.Callstack.from_simpll_yaml(
         macro.callstack[ComparisonGraph.Side.LEFT])
     assert callstack.calls == [
@@ -128,13 +128,26 @@ def test_yaml_output(result, mocker):
     """Tests YAML representation of compare result made by YamlOutput class."""
     mocker.patch("diffkemp.output.get_end_line", return_value=2958)
 
-    # mock relpath to return original path
+    old_snapshot_dir = "/abs/path/to/old-snapshot"
+    new_snapshot_dir = "/abs/path/to/new-snapshot"
+
+    # Mocking relpath to return original path, because the file paths
+    # in vertices and etc. in conftest.py are not absolute
+    # (does not contain path to snapshot).
     def mock_rel_path(path, start):
         return path
     mocker.patch("os.path.relpath", side_effect=mock_rel_path)
 
-    yaml = YamlOutput("/abs/path/to/old-snapshot", "/abs/path/to/new-snapshot",
-                      result).output
+    # Mocking path.join for the same reason as relpath.
+    # Note: This mock can be problem if diffkemp uses >2 paths in join.
+    def mock_path_join(path1, *path2):
+        if len(path2) == 1 and path1 in [old_snapshot_dir, new_snapshot_dir]:
+            return path2[0]
+        else:
+            return mocker.DEFAULT
+    mocker.patch("os.path.join", side_effect=mock_path_join)
+
+    yaml = YamlOutput(old_snapshot_dir, new_snapshot_dir, result).output
 
     assert yaml["old-snapshot"] == "/abs/path/to/old-snapshot"
     assert yaml["new-snapshot"] == "/abs/path/to/new-snapshot"
@@ -145,7 +158,7 @@ def test_yaml_output(result, mocker):
     assert len(main_function_result["diffs"]) == 3
     for diff in main_function_result["diffs"]:
         expected_callstack = []
-        if diff["function"] == "MACRO":
+        if diff["function"] == "___MACRO":
             expected_callstack = [
                 {"name": "do_check", "file": "app/main.c", "line": 58},
                 {"name": "_MACRO (macro)", "file": "test.c", "line": 1},
@@ -165,8 +178,7 @@ def test_yaml_output(result, mocker):
         assert diff["old-callstack"] == expected_callstack
         assert diff["new-callstack"] == expected_callstack
 
-    # note: definitions does not currently include macros
-    assert len(yaml["definitions"]) == 3
+    assert len(yaml["definitions"]) == 6
     for name, definition in yaml["definitions"].items():
         if name == "main_function":
             def_info = {
@@ -186,4 +198,25 @@ def test_yaml_output(result, mocker):
             }
             assert definition == {
                 "kind": "type", "old": def_info, "new": def_info
+            }
+        elif name == "_MACRO":
+            def_info = {
+                "line": 2, "file": "test.c", "end-line": 2958
+            }
+            assert definition == {
+                "kind": "macro", "old": def_info, "new": def_info
+            }
+        elif name == "__MACRO":
+            def_info = {
+                "line": 3, "file": "test.c", "end-line": 2958
+            }
+            assert definition == {
+                "kind": "macro", "old": def_info, "new": def_info
+            }
+        elif name == "___MACRO":
+            def_info = {
+                "line": 4, "file": "test.c", "end-line": 2958
+            }
+            assert definition == {
+                "kind": "macro", "old": def_info, "new": def_info
             }

--- a/view/src/PropTypesValues.js
+++ b/view/src/PropTypesValues.js
@@ -15,7 +15,8 @@ export const DiffPropTypes = PropTypes.shape({
 });
 
 const DefinitionShape = {
-  kind: PropTypes.oneOf(['function', 'type', 'macro']),
+  kind: PropTypes.oneOf(['function', 'type', 'macro', 'macro-function',
+    'function-macro', 'assembly']),
   old: PropTypes.shape({
     line: PropTypes.number,
     file: PropTypes.string,

--- a/view/src/PropTypesValues.js
+++ b/view/src/PropTypesValues.js
@@ -15,7 +15,7 @@ export const DiffPropTypes = PropTypes.shape({
 });
 
 const DefinitionShape = {
-  kind: PropTypes.oneOf(['function', 'type']),
+  kind: PropTypes.oneOf(['function', 'type', 'macro']),
   old: PropTypes.shape({
     line: PropTypes.number,
     file: PropTypes.string,

--- a/view/src/components/Callstack.jsx
+++ b/view/src/components/Callstack.jsx
@@ -180,6 +180,7 @@ function SingleCall({
   }
   return (
     <Calls
+      type={CallType.Both}
       oldCalls={[{ name: oldName }]}
       newCalls={[{ name: newName }]}
       onSelect={onSelect}
@@ -207,7 +208,7 @@ SingleCall.propTypes = {
  * @returns
  */
 function Calls({
-  oldCalls, newCalls, selectedFunction, onSelect,
+  oldCalls, newCalls, selectedFunction, onSelect, type = null,
 }) {
   return (
     <ListGroup horizontal as="ul" className="callstack-call-group">
@@ -219,7 +220,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
-            type={CallType.Old}
+            type={type || CallType.Old}
           />
         ))}
       </ListGroup>
@@ -231,7 +232,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
-            type={CallType.New}
+            type={type || CallType.New}
           />
         ))}
       </ListGroup>
@@ -240,6 +241,7 @@ function Calls({
 }
 
 Calls.propTypes = {
+  type: PropTypes.string,
   oldCalls: CallstackPropTypes.isRequired,
   newCalls: CallstackPropTypes,
   selectedFunction: SelectedFunPropType,
@@ -264,6 +266,11 @@ function Call({
 }) {
   // putting information about type/macro under the name of function
   const nameWrap = name.replace(' ', '<br/>');
+  // Note: Currently checking if the function should be active only based on the name
+  // (kind is omitted). This solves special cases of function-macro/macro-function differences
+  // when we want to show their code at the same time.
+  // If there will be other situations when we want to show code of functions with different
+  // names simultaneously, then this needs to be reworked.
   return (
     <ListGroup.Item
       as="li"
@@ -271,7 +278,8 @@ function Call({
       action
       className="callstack-call"
       onClick={() => onSelect({ name, type })}
-      active={name === selectedFunction?.name && type === selectedFunction?.type}
+      active={name.split(' ')[0] === selectedFunction?.name.split(' ')[0]
+        && type === selectedFunction?.type}
       dangerouslySetInnerHTML={{ __html: nameWrap }}
     />
   );

--- a/view/src/components/Callstack.jsx
+++ b/view/src/components/Callstack.jsx
@@ -5,14 +5,28 @@ import ListGroup from 'react-bootstrap/ListGroup';
 import { PropTypes } from 'prop-types';
 import { CallstackPropTypes, DefinitionsPropTypes } from '../PropTypesValues';
 
+// In which call stack is the call located.
+export const CallType = {
+  Both: 'both',
+  New: 'new',
+  Old: 'old',
+};
+
+const SelectedFunPropType = PropTypes.shape({
+  name: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(CallType)),
+});
+
 /**
  * Component for visualisation of call stack.
  * @param {Object} props
  * @param {string} props.compFunName - First (compared) function name.
- * @param {string} props.selectedFunction - Name of function which is selected
- * and should be highlighted in call stack.
- * @param {Function} props.onSelect - Callback function accepting a function
- * name which was chosen to be shown.
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {String} props.selectedFunction.name - Name of the selected function.
+ * @param {String} props.selectedFunction.type - CallType of the selected function.
+ * @param {Function} props.onSelect - Callback function accepting a selected function,
+ *   the callback is called when call (function) is clicked (selected).
  * @returns Returns call stack component.
  */
 export default function Callstack({
@@ -133,7 +147,7 @@ Callstack.propTypes = {
   compFunName: PropTypes.string.isRequired,
   oldCallStack: CallstackPropTypes.isRequired,
   newCallStack: CallstackPropTypes.isRequired,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
   definitions: DefinitionsPropTypes.isRequired,
 };
@@ -143,9 +157,9 @@ Callstack.propTypes = {
  * @param {Object} props
  * @param {string} props.oldName - Name of old call (function).
  * @param {string} props.newName - Name of new call (function).
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
  * @returns
  */
 function SingleCall({
@@ -160,6 +174,7 @@ function SingleCall({
         name={oldName}
         onSelect={onSelect}
         selectedFunction={selectedFunction}
+        type={CallType.Both}
       />
     );
   }
@@ -176,7 +191,7 @@ function SingleCall({
 SingleCall.propTypes = {
   oldName: PropTypes.string.isRequired,
   newName: PropTypes.string,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
 };
 
@@ -186,9 +201,9 @@ SingleCall.propTypes = {
  * @param {Object} props
  * @param {Object[]} props.oldCalls - Calls from old call stack.
  * @param {Object[]} props.newCalls - Calls from new call stack.
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
  * @returns
  */
 function Calls({
@@ -204,6 +219,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
+            type={CallType.Old}
           />
         ))}
       </ListGroup>
@@ -215,6 +231,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
+            type={CallType.New}
           />
         ))}
       </ListGroup>
@@ -225,7 +242,7 @@ function Calls({
 Calls.propTypes = {
   oldCalls: CallstackPropTypes.isRequired,
   newCalls: CallstackPropTypes,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
 };
 
@@ -233,12 +250,18 @@ Calls.propTypes = {
  * Component for visualisation of call from call stack.
  * @param {Object} props
  * @param {string} props.name - Name of called function/macro/type.
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
+ * @param {string} props.type - TypeCall of the call.
  * @returns
  */
-function Call({ name, selectedFunction, onSelect }) {
+function Call({
+  name,
+  selectedFunction,
+  onSelect,
+  type,
+}) {
   // putting information about type/macro under the name of function
   const nameWrap = name.replace(' ', '<br/>');
   return (
@@ -247,8 +270,8 @@ function Call({ name, selectedFunction, onSelect }) {
       title={name}
       action
       className="callstack-call"
-      onClick={() => onSelect(name)}
-      active={name === selectedFunction}
+      onClick={() => onSelect({ name, type })}
+      active={name === selectedFunction?.name && type === selectedFunction?.type}
       dangerouslySetInnerHTML={{ __html: nameWrap }}
     />
   );
@@ -256,6 +279,7 @@ function Call({ name, selectedFunction, onSelect }) {
 
 Call.propTypes = {
   name: PropTypes.string.isRequired,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
+  type: PropTypes.string.isRequired,
 };

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -9,7 +9,7 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import Alert from 'react-bootstrap/Alert';
 
-import Callstack from './Callstack';
+import Callstack, { CallType } from './Callstack';
 import Code from './Code';
 import { DefinitionsPropTypes, DiffPropTypes } from '../PropTypesValues';
 
@@ -30,66 +30,84 @@ export default function Difference({
   definitions,
   getFile,
 }) {
-  // name of function to be shown (defaultly showing differing function)
-  const [functionToShow, setFunctionToShow] = useState(
-    diff['old-callstack'].length > 0
+  // Function which code to show (defaultly showing the differing function).
+  const [functionToShow, setFunctionToShow] = useState({
+    // If there is no call stack, the differing function is the compared function.
+    name: diff['old-callstack'].length > 0
       ? diff['old-callstack'][diff['old-callstack'].length - 1].name
       : compare,
-  );
+    // Assuming that the differing function is located in both call stacks.
+    type: CallType.Both,
+  });
   let codeBlock = null;
   let errorCodeMessage = null;
   // extracting only name (putting away kind)
-  const name = functionToShow.split(' ')[0];
+  const name = functionToShow.name.split(' ')[0];
+  const { type } = functionToShow;
 
-  if (name in definitions) {
-    const oldDefintion = definitions[name].old;
-    const newDefintion = definitions[name].new;
+  const needsOldCode = (type === CallType.Both || type === CallType.Old);
+  const needsNewCode = (type === CallType.Both || type === CallType.New);
+  const containsDefinition = (name in definitions);
+  const containsOldDef = containsDefinition && 'old' in definitions[name];
+  const containsNewDef = containsDefinition && 'new' in definitions[name];
+  // If need old/new code then it has to contain old/new defintion.
+  // Note: implication X => Y <=> not X or Y
+  if ((!needsOldCode || containsOldDef) && (!needsNewCode || containsNewDef)) {
+    const oldDefintion = definitions[name]?.old;
+    const newDefintion = definitions[name]?.new;
 
-    // returns line where is called next function in callstack
-    // or undefined if it is differing function
+    // Returns tuple (old, new) line where is called next function in the call stack.
+    // The old/new can be set to -1 if there is no next called function (in case
+    // the functionToShow is located only in one call stack).
+    // If there is no called function for both functions (it is differing fun)
+    // returns undefined.
     const getCallingLine = () => {
-      // indexes to callstack containing called function
-      let oldIndex = 0;
-      let newIndex = 0;
-      if (functionToShow !== compare) {
-        oldIndex = diff['old-callstack'].findIndex(
-          (call) => call.name === functionToShow,
-        ) + 1;
-        newIndex = diff['new-callstack'].findIndex(
-          (call) => call.name === functionToShow,
-        ) + 1;
+      let oldLine = -1;
+      let newLine = -1;
+      if (functionToShow.name === compare
+          && diff['old-callstack'].length > 0 && diff['new-callstack'].length > 0) {
+        oldLine = diff['old-callstack'][0].line;
+        newLine = diff['new-callstack'][0].line;
+      } else {
+        const oldIndex = diff['old-callstack'].findIndex(
+          (call) => call.name === functionToShow.name,
+        );
+        const newIndex = diff['new-callstack'].findIndex(
+          (call) => call.name === functionToShow.name,
+        );
+        // Was the function found and it is not the differing function?
+        if (oldIndex >= 0 && oldIndex < diff['old-callstack'].length - 1) {
+          oldLine = diff['old-callstack'][oldIndex + 1].line;
+        }
+        if (newIndex >= 0 && newIndex < diff['new-callstack'].length - 1) {
+          newLine = diff['new-callstack'][newIndex + 1].line;
+        }
       }
-
-      if (
-        diff['old-callstack'].length > oldIndex
-                && diff['new-callstack'].length > newIndex
-      ) {
-        return [
-          diff['old-callstack'][oldIndex].line,
-          diff['new-callstack'][newIndex].line,
-        ];
-      }
-      return undefined;
+      if (oldLine === -1 && newLine === -1) return undefined;
+      return [oldLine, newLine];
     };
-    if (!('end-line' in oldDefintion) || !('end-line' in newDefintion)) {
+    if ((needsOldCode && !('end-line' in oldDefintion))
+        || (needsNewCode && !('end-line' in newDefintion))) {
       errorCodeMessage = 'Missing info about ending of function.';
     } else {
       // creating component for code visualisation
       // if all information are included for showing code of function
       const specification = {
-        oldSrc: oldDefintion.file,
-        newSrc: newDefintion.file,
-        diff: definitions[name].diff
+        oldSrc: needsOldCode ? oldDefintion.file : null,
+        newSrc: needsNewCode ? newDefintion.file : null,
+        diff: type === 'both' && definitions[name].diff
           ? `${name}.diff`
           : null,
-        oldStart: oldDefintion.line,
-        newStart: newDefintion.line,
-        oldEnd: oldDefintion['end-line'],
+        oldStart: needsOldCode ? oldDefintion.line : null,
+        newStart: needsNewCode ? newDefintion.line : null,
+        oldEnd: needsOldCode ? oldDefintion['end-line'] : null,
+        newEnd: needsNewCode ? newDefintion['end-line'] : null,
         calling: getCallingLine(),
+        type,
       };
       codeBlock = (
         <Code
-          key={`${compare}-${functionToShow}`}
+          key={`${compare}-${functionToShow.name}`}
           specification={specification}
           getFile={getFile}
           oldFolder={oldFolder}
@@ -118,6 +136,7 @@ export default function Difference({
           {errorCodeMessage ? (
             <Alert>
               Unable to show code:
+              {' '}
               {errorCodeMessage}
             </Alert>
           ) : (

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -62,6 +62,9 @@ export default function Difference({
     // If there is no called function for both functions (it is differing fun)
     // returns undefined.
     const getCallingLine = () => {
+      // Note: If there will be cases of calls with different names and we will
+      // want to show their code at the same time and the calls will be
+      // calling other functions, then this will need to be reworked.
       let oldLine = -1;
       let newLine = -1;
       if (functionToShow.name === compare

--- a/view/src/tests/Callstack.cy.jsx
+++ b/view/src/tests/Callstack.cy.jsx
@@ -1,6 +1,7 @@
 // Tests of the Callstack component appearance
 
 import Callstack from '../components/Callstack';
+import { MacroFunctionDifference } from './examples';
 
 // Custom query to find a DOM element in the Callstack
 // which represents the called function with the given name
@@ -316,6 +317,22 @@ specify('a complex call stack should be visualised correctly', () => {
     compFunName={compFunName}
     oldCallStack={oldCallStack}
     newCallStack={newCallStack}
+    definitions={{}}
+    onSelect={() => {}}
+  />);
+  checkCallStackAppearance(expectedVisualisation);
+});
+
+specify('a call stack with macro-function difference should be visualised correctly', () => {
+  const expectedVisualisation = [
+    ['down_write'],
+    ['get_task_struct (macro)', 'get_task_struct'],
+  ];
+
+  cy.mount(<Callstack
+    compFunName={MacroFunctionDifference.results[0].function}
+    oldCallStack={MacroFunctionDifference.results[0].diffs[0]['old-callstack']}
+    newCallStack={MacroFunctionDifference.results[0].diffs[0]['new-callstack']}
     definitions={{}}
     onSelect={() => {}}
   />);

--- a/view/src/tests/Callstack.test.jsx
+++ b/view/src/tests/Callstack.test.jsx
@@ -7,6 +7,7 @@ import {
 import '@testing-library/jest-dom';
 
 import Callstack from '../components/Callstack';
+import { MacroFunctionDifference } from './examples';
 
 describe('simple callstack visualisation test', () => {
   const compFunName = '__put_task_struct';
@@ -84,15 +85,12 @@ describe('complex callstack visualisation test', () => {
 });
 
 describe("callstack with 'different' differing functions", () => {
-  const compFunName = 'down_write';
-  const oldCallStack = [{ name: 'get_task_struct (macro)' }];
-  const newCallStack = [{ name: 'get_task_struct' }];
   test('all function names should be visible', () => {
     render(
       <Callstack
-        compFunName={compFunName}
-        oldCallStack={oldCallStack}
-        newCallStack={newCallStack}
+        compFunName={MacroFunctionDifference.results[0].function}
+        oldCallStack={MacroFunctionDifference.results[0].diffs[0]['old-callstack']}
+        newCallStack={MacroFunctionDifference.results[0].diffs[0]['new-callstack']}
         definitions={{}}
         onSelect={() => {}}
       />,

--- a/view/src/tests/Difference.test.jsx
+++ b/view/src/tests/Difference.test.jsx
@@ -120,11 +120,13 @@ test('first shown function should be differing function', async () => {
   await waitFor(() => {
     expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        oldCode: 'src/include/linux/sched.h',
+        oldCode: 'old-src/include/linux/sched.h',
+        newCode: 'new-src/include/linux/sched.h',
         diff: 'diffs/task_struct.diff',
         oldStart: 594,
         newStart: 594,
         oldEnd: 1217,
+        newEnd: 1261,
         showDiff: true,
         linesToShow: null,
       }),
@@ -152,11 +154,13 @@ describe('after click on function in callstack', () => {
     await waitFor(() => {
       expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          oldCode: 'src/kernel/pid.c',
+          oldCode: 'old-src/kernel/pid.c',
+          newCode: 'new-src/kernel/pid.c',
           diff: '',
           oldStart: 438,
           newStart: 443,
           oldEnd: 441,
+          newEnd: 446,
           showDiff: false,
           linesToShow: [440, 445],
         }),

--- a/view/src/tests/examples.js
+++ b/view/src/tests/examples.js
@@ -1,0 +1,22 @@
+// Examples of differences (real or created) for testing functionality of the viewer
+
+/* eslint import/prefer-default-export: "off" */
+
+export const MacroFunctionDifference = {
+  results: [{
+    // compared function
+    function: 'down_write',
+    diffs: [{
+      // differing function
+      function: 'get_task_struct',
+      'old-callstack': [{ name: 'get_task_struct (macro)' }],
+      'new-callstack': [{ name: 'get_task_struct' }],
+    }],
+  }],
+  // Expected call stack visualisation:
+  // ----------------------------------------------------------------
+  // | down_write                                                   |
+  // |--------------------------------------------------------------|
+  // | get_task_struct (macro)         | get_task_struct            |
+  // ----------------------------------------------------------------
+};


### PR DESCRIPTION
This PR adds visualisations of macros to the result viewer.

It was necessary to get information about definitions of macros. I did not use `cscope` because there can be multiple macros with the same name, I took advantage of the fact that the call stack for macros does not contain a line from where it is called at the macro but the line where the macro starts  (btw. I am not sure that this is expected behaviour, I think that it probably should be also a line from which is called the macro as it is for functions).
For the last macro in the call stack, the information about the definition is extracted from Simpll and passed down to DiffKemp and the result viewer.

Also, this PR extends the function, for getting a line where function/type ends, for getting it also for macros.

Because the macros can appear only on one side/version of the call stack, it was necessary to edit components of the viewer and copy also new source files to viewer dir (subdir `new-src`), the dir for the old source files is renamed to `old-src`.

This PR also extends the viewer for visualisation of macro-function/function-macro differences. To make this possible information about the SyntaxDifference kind (macro, macro-function, function-macro, assembly) is added and necessary information about definitions are extracted from LLVM IR (there is a case when the information is not possible to be extracted if the LLVM IR contains information only about declaration of the function and not about its definition).

I compared 8.0, 8.1, 8.2, 8.3 and 8.4 versions of RHEL/CentOS to check I did not break the comparison.
And I went over some differences in the viewer.

Screenshots of the visualisation:

Macro code
![image](https://github.com/viktormalik/diffkemp/assets/80856731/eff7c5a3-2034-40b8-bd7d-f77b4a2b9a02)
Macro which is only located in the old call stack
![image](https://github.com/viktormalik/diffkemp/assets/80856731/f914f98d-060b-48b6-9385-60272ebccd4a)
Macro which is only located in the new call stack
![image](https://github.com/viktormalik/diffkemp/assets/80856731/d95aeb3d-eb7d-462a-a521-2f9e2923370f)
Macro code
![image](https://github.com/viktormalik/diffkemp/assets/80856731/d2c77be1-04c0-450f-8338-bd6de11054a6)
Macro difference
![image](https://github.com/viktormalik/diffkemp/assets/80856731/3628aaee-f329-4467-b3d1-33f82ec71693)
Macro-function difference
![image](https://github.com/viktormalik/diffkemp/assets/80856731/4bca64fc-3ce3-428e-9b2e-1eeb81aea447)
