### PR TITLE
Check types when applying inverse cond pattern

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -104,6 +104,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Compare two instructions along with their operands.
     int cmpOperationsWithOperands(const Instruction *L,
                                   const Instruction *R) const;
+    /// Compare operand types of two instructions.
+    int cmpOperandTypes(const Instruction *L, const Instruction *R) const;
     /// Detect cast instructions and ignore them when comparing the control flow
     /// only. (The rest is the same as in LLVM.)
     int cmpBasicBlocks(const BasicBlock *BBL,


### PR DESCRIPTION
In certain conditions, not checking the type could lead to an assertion failure in cmpOperationsWithOperands. FunctionComparator::cmpOperations checks the types of operands, however if the instructions are an inverse icmp instructions, Diffkemp discards this result. We need to differentiate, whether the non-zero return code from cmpOperations was caused by a difference in types or difference in values before applying the pattern.

The attached test resulted in an assertion failure with current diffkemp version on this line:

https://github.com/diffkemp/diffkemp/blob/789ac18c2c6864b003eac2d77d155cdf87da0a72/diffkemp/simpll/DifferentialFunctionComparator.cpp#L1849-L1850

I thought of two possible solutions to this problem:

1. the one submitted in this PR
2. checking type equality in `DifferentialFunctionComparator::cmpValues`

The second option sounds a bit cleaner but I feel like it could have some side-effects that I may not be aware of (since the method is called quite often from various contexts) and it may be intentional that the comparison is left out. Therefore, I decided to use the "safer" alternative.