### PR TITLE
Check relocation validity before marking it Stored

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -1991,14 +1991,13 @@ bool DifferentialFunctionComparator::findMatchingOpWithOffset(
             while (isDebugInfo(*end))
                 end--;
             Reloc.end = end;
-            Reloc.status = RelocationInfo::Stored;
-            Reloc.prog = prog_to_search;
-            Reloc.tryInlineBackup = tryInlineBackup;
-
             // Make sure that the first equal instruction is not depending on
             // the relocation
             if (isDependingOnReloc(*MovedInst))
                 return false;
+            Reloc.status = RelocationInfo::Stored;
+            Reloc.prog = prog_to_search;
+            Reloc.tryInlineBackup = tryInlineBackup;
 
             LOG("Possible relocation found:\n"
                 << "    from: " << *Reloc.begin << "\n"


### PR DESCRIPTION
If the first equal instruction depends on the relocation, the relocation is not valid, i.e. we return false from findMatchingOpWithOffset. However, in this case we need to keep the Reloc status as None, since otherwise, we may end up with an inconsistent relocation state, e.g. the first call to findMatchingOpWithOffset sets the status to Stored but returns false due to a dependency and then the second call to findMatchingOpWithOffset replaces Reloc.begin. This way, we end up with a relocation with status Stored and Reloc.begin and Reloc.end pointing to different functions.