### PR TITLE
cc wrapper: skipping not C files

### DIFF
--- a/diffkemp/building/cc_wrapper.py
+++ b/diffkemp/building/cc_wrapper.py
@@ -119,12 +119,15 @@ def wrapper(argv):
     linking_with_sources = False
     output_file = None
     linking = "-c" not in argv
+    # Check if arguments contains C source file
+    contains_source = False
     for index, arg in enumerate(argv):
         if arg in drop:
             continue
         is_object_file = (arg.endswith(".o") or arg.endswith(".lo") or
                           arg.endswith(".ko"))
         is_source_file = arg.endswith(".c")
+        contains_source = contains_source or is_source_file
         if index > 1 and argv[index - 1] == "-o":
             if is_object_file and not linking:
                 # Compiling to object file: swap .o with .ll
@@ -156,6 +159,10 @@ def wrapper(argv):
 
     # Do not run clang on conftest files
     if output_file in ["conftest.ll", "conftest.llw"] or "conftest.c" in argv:
+        return 0
+
+    # Not compiling C source file
+    if not linking and not contains_source:
         return 0
 
     # Record file in database

--- a/tests/testing_projects/make_based/Makefile
+++ b/tests/testing_projects/make_based/Makefile
@@ -2,9 +2,18 @@
 CC = gcc
 CFLAGS = -O2 -std=c99
 
-.PHONY: all clean
+.PHONY: default with-assembly clean
 
-all: file.o
+default: file.o
+
+# Assembly files should not be compiled to `.ll`
+with-assembly: default mod.o sub.o
+
+# Note: mod.o (mod.S) is implicitly compiled using CC, but sub.o (sub.s)
+#   is implicilty compiled using AS therefore for sub.o is neccessary to
+#   add explicit target to use CC (for testing cc_wrapper behaviour).
+sub.o: sub.s
+	$(CC) -c $@ $^
 
 clean:
 	rm -f *.o *.ll

--- a/tests/testing_projects/make_based/Makefile
+++ b/tests/testing_projects/make_based/Makefile
@@ -2,12 +2,15 @@
 CC = gcc
 CFLAGS = -O2 -std=c99
 
-.PHONY: default with-assembly clean
+.PHONY: default with-assembly with-linking clean
 
 default: file.o
 
 # Assembly files should not be compiled to `.ll`
 with-assembly: default mod.o sub.o
+
+# Compilation with linking, should be compiled to `.llw`
+with-linking: default file.so
 
 # Note: mod.o (mod.S) is implicitly compiled using CC, but sub.o (sub.s)
 #   is implicilty compiled using AS therefore for sub.o is neccessary to
@@ -15,5 +18,9 @@ with-assembly: default mod.o sub.o
 sub.o: sub.s
 	$(CC) -c $@ $^
 
+# For testing of compilation of object file to shared library
+file.so: file.o
+	$(CC) $(CFLAGS) -o $@ $^ -shared
+
 clean:
-	rm -f *.o *.ll
+	rm -f *.o *.ll *.so

--- a/tests/testing_projects/make_based/mod.S
+++ b/tests/testing_projects/make_based/mod.S
@@ -1,0 +1,20 @@
+// File for testing of building of snapshots,
+// this file should NOT be compiled to .ll and added to db file.
+// Note: File was compiled from a C file, trimmed and edited.
+    .text
+    .p2align 4
+    .globl mod
+    .type mod, @function
+mod:
+    endbr64
+    movl %edi, %eax
+#ifdef MOD_SIGNED
+    cltd
+    idivl %esi
+#else
+    xorl %edx, %edx
+    divl %esi
+#endif
+    movl %edx, %eax
+    ret
+

--- a/tests/testing_projects/make_based/sub.s
+++ b/tests/testing_projects/make_based/sub.s
@@ -1,0 +1,13 @@
+# File for testing of building of snapshots,
+# this file should NOT be compiled to .ll and added to db file.
+# Note: File was compiled from a C file and trimmed.
+    .text
+    .p2align 4
+    .globl sub
+    .type sub, @function
+sub:
+    endbr64
+    movl %edi, %eax
+    subl %esi, %eax
+    ret
+

--- a/tests/unit_tests/build_test.py
+++ b/tests/unit_tests/build_test.py
@@ -80,3 +80,17 @@ def test_make_based_with_assembly(tmp_path):
     db_file_content = get_db_file_content(output_dir)
     assert "mod.ll" not in db_file_content
     assert "sub.ll" not in db_file_content
+
+
+def test_make_based_with_linking(tmp_path):
+    """Tests make based project which contains linking of file(s)."""
+    output_dir = str(tmp_path)
+    args = Arguments(MAKE_BASED_PROJECT_DIR, output_dir,
+                     target=["with-linking"])
+    build(args)
+    # When linking *.o files, appropriate .ll files
+    # should be linked with llvm-link and saved as `.llw`.
+    # Note: The .llw is not copied to snapshot dir.
+    assert "file.so.llw" in os.listdir(MAKE_BASED_PROJECT_DIR)
+    db_file_content = get_db_file_content(output_dir)
+    assert "file.so.llw" in db_file_content


### PR DESCRIPTION
The cc wrapper used to try to compile also assembly, this PR changes it by checking if arguments contain a C source file (`*.c`) if not then it does not tries to compile it. For commands containing linking changes nothing.

To check if I did not break anything I build `musl-1.2.1` -- `musl-1.2.5` and compared snapshots between master and this branch, the snapshots between the branches contain the same files. In musl there were some cases of compilation `*.s` files, before this PR cc_wrapper did try to compile it but because the compilation did not created output file, the file was never added to db file https://github.com/diffkemp/diffkemp/blob/54deef1fbdaabbc6014223a2cf1b4418641b76bb/diffkemp/building/cc_wrapper.py#L210. Now it does not even try to compile it.

I also build `dietlibc-0.34`, for this library there were before this PR multiple cases of `*.S` files compilation, because the compilation did not failed, the output file was created and added to db file. For this I also compared snapshots created on master branch and this branch, the snapshots contains same files (the `*.S` files are compiled on master branch but because they do not contain LLVM IR functions they were/are not copied to snapshot dir, therefore the snapshots still contains the same files). Now the `*.S` files are not compiled and therefore not added to db file. 
