### PR TITLE
Build: Cleaning temporary directory

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -131,6 +131,8 @@ def build_c_project(args):
     # Create the snapshot directory containing the YAML description file
     snapshot.generate_snapshot_dir()
     snapshot.finalize()
+    # Removing the tmp dir with diffkemp-wdb file
+    shutil.rmtree(tmpdir)
 
 
 def build_c_file(args):


### PR DESCRIPTION
Temporary directory for cc_wrapper db file was never cleaned up. Added removal of the directory.