### PR TITLE
Fix handling of union types

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -88,6 +88,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Such calls are compared as equal if they only differ in the last
     /// argument which is 0 or NULL.
     int cmpCallsWithExtraArg(const CallInst *CL, const CallInst *CR) const;
+    /// Checks whether the given type is a union.
+    static bool isUnionTy(const Type *Ty);
     /// Compares array types with equivalent element types and all integer types
     /// as equal when comparing the control flow only.
     int cmpTypes(Type *L, Type *R) const override;


### PR DESCRIPTION
Union types from C are represented by a structure type in LLVM IR generated by clang. When we are applying the StructAlignment pattern, there is, therefore, some ambiguity.

The previous implementation did not work correctly if C union and C structure types were being compared in cmpTypes -- the result was dependant on what was the Left and Right type due to a bug in the implementation. In this case, Left would be considered as the potential union type, even if it was the other way around.

Reproducer of the bug -- swapping the order of snapshots influences the analysis verdict:
```
$ bin/diffkemp -v compare ../diffkemp-experiments/kabi/snapshots/linux-4.18.0-240.el8 ../diffkemp-experiments/kabi/snapshots/linux-4.18.0-305.el8 --report-stat --extended-stat -f rcu_barrier

$ bin/diffkemp -v compare ../diffkemp-experiments/kabi/snapshots/linux-4.18.0-305.el8 ../diffkemp-experiments/kabi/snapshots/linux-4.18.0-240.el8 --report-stat --extended-stat -f rcu_barrier
```