### PR TITLE
Caching information about definitions of differing macros

### DIFF
--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -225,23 +225,34 @@ class ComparisonGraph:
             but the line where the definition of the caller starts.
         :param body: A tuple containing the body of the 'object' for both
             modules.
+        :param diff_def: Tuple (first, second), for macro difference contains
+            information about definition (name, file, line) of the differing
+            macros, otherwise contains None.
         """
-        def __init__(self, kind, name, parent_fun, callstack, body):
+        def __init__(self, kind, name, parent_fun, callstack, body,
+                     diff_def=None):
             self.kind = kind
             self.name = name
             self.parent_fun = parent_fun
             self.callstack = callstack
             self.body = body
+            self.diff_def = diff_def
 
         @classmethod
         def from_yaml(cls, nonfun_diff):
             """Generates a SyntaxDiff object from YAML returned by SimpLL."""
+            diff_def = None
+            if ("diff-def-first" in nonfun_diff and
+                    "diff-def-second" in nonfun_diff):
+                diff_def = (nonfun_diff["diff-def-first"],
+                            nonfun_diff["diff-def-second"])
             return cls(
                 nonfun_diff["kind"],
                 nonfun_diff["name"],
                 nonfun_diff["function"],
                 (nonfun_diff["stack-first"], nonfun_diff["stack-second"]),
-                (nonfun_diff["body-first"], nonfun_diff["body-second"])
+                (nonfun_diff["body-first"], nonfun_diff["body-second"]),
+                diff_def
             )
 
     class TypeDiff(NonFunDiff):

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -209,10 +209,25 @@ class ComparisonGraph:
     class SyntaxDiff(NonFunDiff):
         """
         A syntax difference.
-
-        Note: body is a tuple containing the values for both modules.
+        :param kind: The kind of difference: 'macro', 'assembly',
+            'function-macro', 'macro-function', 'unknown'.
+        :param name: Name of an 'object' (eg. macro) in the first module in
+            which was found difference. In case of inline assembly difference
+            the name starts with "assembly code " followed by a number.
+        :param parent_fun: Name of vertex in which was the syntax diff found.
+        :param callstack: Tuple (call stack in first module, second one),
+            both call stacks are list containing calls, where each
+            call is dict with keys `file`, `line`, `weak`, `function`.
+            The `function` contains the name of called 'object',
+            in the case of macro it has extension " (macro)".
+            If the call is called from another macro then `line` does not
+            represent the line at which is the call called
+            but the line where the definition of the caller starts.
+        :param body: A tuple containing the body of the 'object' for both
+            modules.
         """
-        def __init__(self, name, parent_fun, callstack, body):
+        def __init__(self, kind, name, parent_fun, callstack, body):
+            self.kind = kind
             self.name = name
             self.parent_fun = parent_fun
             self.callstack = callstack
@@ -222,6 +237,7 @@ class ComparisonGraph:
         def from_yaml(cls, nonfun_diff):
             """Generates a SyntaxDiff object from YAML returned by SimpLL."""
             return cls(
+                nonfun_diff["kind"],
                 nonfun_diff["name"],
                 nonfun_diff["function"],
                 (nonfun_diff["stack-first"], nonfun_diff["stack-second"]),

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -446,6 +446,9 @@ void DifferentialFunctionComparator::findMacroFunctionDifference(
 
         std::unique_ptr<SyntaxDifference> diff =
                 std::make_unique<SyntaxDifference>();
+        diff->syntaxKind = (NameL == trueName)
+                                   ? SyntaxDifference::Kind::FUNCTION_MACRO
+                                   : SyntaxDifference::Kind::MACRO_FUNCTION;
         diff->function = L->getFunction()->getName().str();
         diff->name = trueName;
         diff->BodyL = "[macro function difference]";
@@ -1219,6 +1222,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
     // Note: the call stack is left empty here, it will be added in reportOutput
     std::unique_ptr<SyntaxDifference> diff =
             std::make_unique<SyntaxDifference>();
+    diff->syntaxKind = SyntaxDifference::Kind::ASSEMBLY;
     diff->BodyL = AsmL.str() + " (args: " + argumentNamesL + ")";
     diff->BodyR = AsmR.str() + " (args: " + argumentNamesR + ")";
     diff->StackL = CallStack();

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -67,6 +67,20 @@ template <> struct MappingTraits<FunctionInfo> {
 } // namespace yaml
 } // namespace llvm
 
+// Information about code location (stored in unique_ptr) of an 'object'
+// (eg. definition of macro in SyntaxDifference) to YAML.
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<std::unique_ptr<CodeLocation>> {
+    static void mapping(IO &io, std::unique_ptr<CodeLocation> &loc) {
+        io.mapRequired("name", loc->name);
+        io.mapRequired("file", loc->sourceFile);
+        io.mapRequired("line", loc->line);
+    }
+};
+} // namespace yaml
+} // namespace llvm
+
 // SyntaxDifference::SyntaxKind to YAML
 namespace llvm {
 namespace yaml {
@@ -98,6 +112,11 @@ template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
             io.mapOptional("kind", syntaxDiff->syntaxKind);
             io.mapOptional("body-first", syntaxDiff->BodyL);
             io.mapOptional("body-second", syntaxDiff->BodyR);
+            if (syntaxDiff->diffDefL && syntaxDiff->diffDefR) {
+                // Information about definitions of differing 'objects'.
+                io.mapOptional("diff-def-first", syntaxDiff->diffDefL);
+                io.mapOptional("diff-def-second", syntaxDiff->diffDefR);
+            }
         } else if (auto typeDiff = unique_dyn_cast<TypeDifference>(diff)) {
             io.mapOptional("file-first", typeDiff->FileL);
             io.mapOptional("file-second", typeDiff->FileR);

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -67,6 +67,23 @@ template <> struct MappingTraits<FunctionInfo> {
 } // namespace yaml
 } // namespace llvm
 
+// SyntaxDifference::SyntaxKind to YAML
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<SyntaxDifference::Kind> {
+    static void enumeration(IO &io, SyntaxDifference::Kind &kind) {
+        io.enumCase(kind, "macro", SyntaxDifference::Kind::MACRO);
+        io.enumCase(
+                kind, "macro-function", SyntaxDifference::Kind::MACRO_FUNCTION);
+        io.enumCase(
+                kind, "function-macro", SyntaxDifference::Kind::FUNCTION_MACRO);
+        io.enumCase(kind, "assembly", SyntaxDifference::Kind::ASSEMBLY);
+        io.enumCase(kind, "unknown", SyntaxDifference::Kind::UNKNOWN);
+    }
+};
+} // namespace yaml
+} // namespace llvm
+
 // NonFunctionDifference (stored in unique_ptr) to YAML
 namespace llvm {
 namespace yaml {
@@ -78,6 +95,7 @@ template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
         io.mapRequired("stack-second", diff->StackR);
 
         if (auto syntaxDiff = unique_dyn_cast<SyntaxDifference>(diff)) {
+            io.mapOptional("kind", syntaxDiff->syntaxKind);
             io.mapOptional("body-first", syntaxDiff->BodyL);
             io.mapOptional("body-second", syntaxDiff->BodyR);
         } else if (auto typeDiff = unique_dyn_cast<TypeDifference>(diff)) {

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -127,6 +127,10 @@ struct SyntaxDifference : public NonFunctionDifference {
     Kind syntaxKind;
     /// The difference.
     std::string BodyL, BodyR;
+    // Information about definitions of differing 'object'.
+    // For now it is only used in macro differences, for other differences it is
+    // null.
+    std::unique_ptr<CodeLocation> diffDefL, diffDefR;
     SyntaxDifference()
             : NonFunctionDifference(SynDiff), syntaxKind(Kind::UNKNOWN){};
     SyntaxDifference(Kind syntaxKind,
@@ -135,9 +139,12 @@ struct SyntaxDifference : public NonFunctionDifference {
                      std::string BodyR,
                      CallStack StackL,
                      CallStack StackR,
-                     std::string function)
+                     std::string function,
+                     std::unique_ptr<CodeLocation> diffDefL,
+                     std::unique_ptr<CodeLocation> diffDefR)
             : NonFunctionDifference(name, StackL, StackR, function, SynDiff),
-              syntaxKind(syntaxKind), BodyL(BodyL), BodyR(BodyR) {}
+              syntaxKind(syntaxKind), BodyL(BodyL), BodyR(BodyR),
+              diffDefL(std::move(diffDefL)), diffDefR(std::move(diffDefR)) {}
     static bool classof(const NonFunctionDifference *Diff) {
         return Diff->getKind() == SynDiff;
     }

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -79,6 +79,20 @@ struct FunctionInfo {
     }
 };
 
+/// Type for storing information about code location of an 'object'
+/// (eg. location of macro definition).
+struct CodeLocation {
+    // Name of the 'object'.
+    std::string name;
+    // Line in the sourceFile.
+    unsigned line;
+    // A C source file name.
+    std::string sourceFile;
+    CodeLocation() = default;
+    CodeLocation(std::string name, unsigned line, std::string sourceFile)
+            : name(name), line(line), sourceFile(sourceFile) {}
+};
+
 /// Generic type for non-function differences.
 struct NonFunctionDifference {
     /// Discriminator for LLVM-style RTTI (dyn_cast<> et al.)

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -106,19 +106,24 @@ struct NonFunctionDifference {
 
 /// Syntactic difference between objects that cannot be found in the original
 /// source files.
-/// Note: this can be either a macro difference or inline assembly difference.
+/// There are multiple kinds of the differences: a macro diff,
+/// inline assembly diff, function-macro diff or macro-function diff.
 struct SyntaxDifference : public NonFunctionDifference {
+    enum Kind { UNKNOWN, MACRO, ASSEMBLY, FUNCTION_MACRO, MACRO_FUNCTION };
+    Kind syntaxKind;
     /// The difference.
     std::string BodyL, BodyR;
-    SyntaxDifference() : NonFunctionDifference(SynDiff){};
-    SyntaxDifference(std::string name,
+    SyntaxDifference()
+            : NonFunctionDifference(SynDiff), syntaxKind(Kind::UNKNOWN){};
+    SyntaxDifference(Kind syntaxKind,
+                     std::string name,
                      std::string BodyL,
                      std::string BodyR,
                      CallStack StackL,
                      CallStack StackR,
                      std::string function)
             : NonFunctionDifference(name, StackL, StackR, function, SynDiff),
-              BodyL(BodyL), BodyR(BodyR) {}
+              syntaxKind(syntaxKind), BodyL(BodyL), BodyR(BodyR) {}
     static bool classof(const NonFunctionDifference *Diff) {
         return Diff->getKind() == SynDiff;
     }

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -298,6 +298,12 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                                               << elem.file << " on line "
                                               << elem.line << "\n");
             };
+            // Copying info about differing macros definition for the 'user' so
+            // he knows where the difference was found (eg. for showing diff).
+            auto diffDefL =
+                    std::make_unique<CodeLocation>(*MacroUseL.second.def);
+            auto diffDefR =
+                    std::make_unique<CodeLocation>(*MacroUseR->second.def);
 
             result.push_back(std::make_unique<SyntaxDifference>(
                     SyntaxDifference::Kind::MACRO,
@@ -306,7 +312,9 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                     MacroUseR->second.def->body.str(),
                     StackL,
                     StackR,
-                    L->getFunction()->getName().str()));
+                    L->getFunction()->getName().str(),
+                    std::move(diffDefL),
+                    std::move(diffDefR)));
         }
     }
 

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -300,6 +300,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
             };
 
             result.push_back(std::make_unique<SyntaxDifference>(
+                    SyntaxDifference::Kind::MACRO,
                     MacroUseL.second.def->name,
                     MacroUseL.second.def->body.str(),
                     MacroUseR->second.def->body.str(),

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -26,19 +26,14 @@
 
 using namespace llvm;
 
-/// Macro definition containing name, body, location, and parameters
-struct MacroDef {
-    // The macro name is shortened, therefore it has to be stored as the whole
-    // string, not as a StringRef (otherwise the content would be dropped after
-    // the block in which the shortening is done).
-    std::string name;
+/// Specialisation of CodeLocation from "Result.h", contains more information
+/// about macro definition (body, parameters, ...) which are used for finding
+/// macro difference.
+struct MacroDef : public CodeLocation {
     // Full macro name (including parameters).
     std::string fullName;
     // The body is in DebugInfo therefore it can be stored by reference.
     StringRef body;
-    // Location of the macro definition in C source.
-    int line;
-    std::string sourceFile;
     // List of the macro parameters.
     std::vector<std::string> params;
 };

--- a/tests/unit_tests/caching_test.py
+++ b/tests/unit_tests/caching_test.py
@@ -169,11 +169,11 @@ def test_graph_to_fun_pair_list(graph):
         graph.graph_to_fun_pair_list("main_function", "main_function", False)
     for side in [0, 1]:
         assert {obj[side].name for obj in objects_to_compare} == {
-            "do_check", "MACRO", "struct_file"}
+            "do_check", "___MACRO", "struct_file"}
         do_check = [obj[side] for obj in objects_to_compare
                     if obj[side].name == "do_check"][0]
         macro = [obj[side] for obj in objects_to_compare
-                 if obj[side].name == "MACRO"][0]
+                 if obj[side].name == "___MACRO"][0]
         struct_file = [obj[side] for obj in objects_to_compare
                        if obj[side].name == "struct_file"][0]
         assert do_check.filename == "app/main.c"
@@ -198,8 +198,8 @@ def test_graph_to_fun_pair_list(graph):
         assert not struct_file.covered
     # All results should be not equal.
     assert {obj[2] for obj in objects_to_compare} == {Result.Kind.NOT_EQUAL}
-    assert syndiff_bodies_left == {"MACRO": "5"}
-    assert syndiff_bodies_right == {"MACRO": "5L"}
+    assert syndiff_bodies_left == {"___MACRO": "5"}
+    assert syndiff_bodies_right == {"___MACRO": "5L"}
 
 
 def test_populate_predecessor_lists(graph):

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -39,7 +39,7 @@ def graph():
     )
     # Non-function differences
     g["do_check"].nonfun_diffs.append(ComparisonGraph.SyntaxDiff(
-        "MACRO", "do_check",
+        "macro", "MACRO", "do_check",
         dup([
             {"function": "_MACRO (macro)", "file": "test.c", "line": 1},
             {"function": "__MACRO (macro)", "file": "test.c", "line": 2},

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -39,12 +39,13 @@ def graph():
     )
     # Non-function differences
     g["do_check"].nonfun_diffs.append(ComparisonGraph.SyntaxDiff(
-        "macro", "MACRO", "do_check",
+        "macro", "___MACRO", "do_check",
         dup([
             {"function": "_MACRO (macro)", "file": "test.c", "line": 1},
             {"function": "__MACRO (macro)", "file": "test.c", "line": 2},
             {"function": "___MACRO (macro)", "file": "test.c", "line": 3},
-        ]), ("5", "5L")
+        ]), ("5", "5L"),
+        dup({"name": "___MACRO", "file": "test.c", "line": 4})
     ))
     g["do_check"].nonfun_diffs.append(ComparisonGraph.TypeDiff(
         "struct_file", "do_check",

--- a/tests/unit_tests/result_test.py
+++ b/tests/unit_tests/result_test.py
@@ -20,7 +20,7 @@ def test_callstack_from_simpll_yaml(graph):
     """Tests creation of Callstack from representation used in non-fun diffs.
     """
     macro = [nonfun_diff for nonfun_diff in graph["do_check"].nonfun_diffs
-             if nonfun_diff.name == "MACRO"][0]
+             if nonfun_diff.name == "___MACRO"][0]
     callstack = Result.Callstack.from_simpll_yaml(
         macro.callstack[ComparisonGraph.Side.LEFT])
     assert callstack.calls == [
@@ -145,7 +145,7 @@ def test_yaml_output(result, mocker):
     assert len(main_function_result["diffs"]) == 3
     for diff in main_function_result["diffs"]:
         expected_callstack = []
-        if diff["function"] == "MACRO":
+        if diff["function"] == "___MACRO":
             expected_callstack = [
                 {"name": "do_check", "file": "app/main.c", "line": 58},
                 {"name": "_MACRO (macro)", "file": "test.c", "line": 1},


### PR DESCRIPTION
First part of commits from #314 .
This PR adds:
- caching of Syntax difference kind (because there can be multiple kinds of syntax differences - `macro`, `assembly`, `macro-function`, `function-macro`) --  I think it could be useful to have this saved in Python, personally I used this information for visualisation of `function-macro`/`macro-function` differences in the result viewer, but right now I am thinking it is not absolutely necessary because I should be able to deduce this based on names of the differing 'objects', but I am still thinking it could be useful to have it.
- caching of the definition of differing/last macro in Syntax difference -- this is useful for showing code/differences of the macro in the result viewer.

I will reference comments/questions from #314 which are relevant to this PR.