### PR TITLE
Nix: add runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,19 @@
               pipInstallPhase
               install -m 0755 bin/diffkemp $out/bin/diffkemp
             '';
+
+            postFixup = ''
+              # Adding runtime dependencies to the PATH when running DiffKemp
+              wrapProgram $out/bin/diffkemp --prefix PATH : ${lib.makeBinPath [
+                llvmPackages.clangNoLibcxx
+                llvmPackages.libllvm.dev
+                llvmPackages.libllvm
+                diffutils
+                cscope
+                gnumake
+                gcc
+              ]}
+            '';
           };
 
       mkDiffkempDevShell =


### PR DESCRIPTION
When running DiffKemp using binary build by nix (`result/bin/diffkemp`), DiffKemp did not work if the user did not install the dependencies that are used at runtime (like llvm - opt, llvm-config, ...) on his local machine. This commit wraps the necessary dependencies to the program.

Note: It looks like this change creates a problem eg. if the user installs dependencies for building the kernel (like libelf-dev, ...) on his local machine and then he would run `result/bin/diffkemp build-kernel`. He would be unable to build the kernel because the wrapped dependencies (clang/gcc) would not find the locally installed dependencies (libelf-dev, ...).