### PR TITLE
RPM fixes for version 0.6.0

### DIFF
--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -13,7 +13,6 @@ BuildRequires:  gcc gcc-c++ cmake ninja-build
 BuildRequires:  llvm-devel
 BuildRequires:  python3-devel python3-pip python3-setuptools python2
 BuildRequires:  git
-BuildRequires:  /usr/bin/pathfix.py
 BuildRequires:  npm
 Requires:       cscope
 Requires:       clang llvm-devel
@@ -51,7 +50,7 @@ mkdir -p %{buildroot}/%{_bindir}
 install -m 0755 bin/%{name} %{buildroot}/%{_bindir}/%{name}
 # Python part
 %py3_install
-pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/diffkemp-cc-wrapper.py
+%py3_shebang_fix %{buildroot}%{_bindir}/diffkemp-cc-wrapper.py
 
 
 %check

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -19,6 +19,7 @@ Requires:       cscope
 Requires:       clang llvm-devel
 Requires:       make
 Requires:       diffutils
+Requires:       python3-setuptools
 
 %{?python_enable_dependency_generator}
 

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -14,6 +14,7 @@ BuildRequires:  llvm-devel
 BuildRequires:  python3-devel python3-pip python3-setuptools python2
 BuildRequires:  git
 BuildRequires:  npm
+BuildRequires:  gtest-devel
 Requires:       cscope
 Requires:       clang llvm-devel
 Requires:       make


### PR DESCRIPTION
Several RPM fixes were necessary when building version 0.6.0:
- Replace `pathfix.py ... FILE` by `%py3_shebang_fix FILE` as recommended by a [Fedora change](https://bugzilla.redhat.com/show_bug.cgi?id=1868347).
- Add `BuildRequires: gtest-devel` as we're not vendoring GoogleTest by default.
- Add `Requires: python3-setuptools` to fix #334.