### PR TITLE
Viewer: Refactoring of view command implementation

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -26,6 +26,8 @@ import shutil
 import yaml
 
 VIEW_INSTALL_DIR = "/var/lib/diffkemp/view"
+# Name of YAML output file created by diffkemp compare command.
+YAML_FILE_NAME = "diffkemp-out.yaml"
 
 
 def build(args):
@@ -500,7 +502,7 @@ def compare(args):
         new_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_new), "")
         yaml_output = YamlOutput(snapshot_dir_old=old_dir_abs,
                                  snapshot_dir_new=new_dir_abs, result=result)
-        yaml_output.save(output_dir=output_dir, file_name="diffkemp-out.yaml")
+        yaml_output.save(output_dir=output_dir, file_name=YAML_FILE_NAME)
     config.snapshot_first.finalize()
     config.snapshot_second.finalize()
 
@@ -622,89 +624,148 @@ def view(args):
     View the compare differences. Prepares files for the visualisation
     and runs viewer.
     """
-    # Load yaml describing results
-    YAML_FILE_NAME = "diffkemp-out.yaml"
-    yaml_path = os.path.join(args.compare_output_dir, YAML_FILE_NAME)
-    if not os.path.exists(yaml_path):
-        sys.stderr.write(
-            "ERROR: compare output is missing file " + f"'{YAML_FILE_NAME}'\n")
-        sys.exit(errno.EINVAL)
-    with open(yaml_path, "r") as file:
-        yaml_result = yaml.safe_load(file)
+    viewer = Viewer(compare_output_dir=args.compare_output_dir,
+                    devel=args.devel)
+    viewer.run()
 
-    # Determine the view_directory.
-    # The manually built one has priority over the installed one.
-    # public_directory: Path to folder which viewer can access.
-    view_directory = os.path.join(os.path.dirname(__file__), "../view")
-    # Manually build one
-    if os.path.exists(view_directory):
-        if args.devel:
-            public_directory = os.path.join(view_directory, "public")
-        else:
-            public_directory = os.path.join(view_directory, "build")
-            if not os.path.isdir(public_directory):
-                sys.stderr.write(
-                    "Could not find production build of the viewer.\n" +
-                    "Use --devel to run a development server " +
-                    "or execute CMake with -DBUILD_VIEWER=On.\n")
-                sys.exit(errno.ENOENT)
-    # Installed one
-    elif os.path.exists(VIEW_INSTALL_DIR):
-        view_directory = VIEW_INSTALL_DIR
-        public_directory = VIEW_INSTALL_DIR
-        if args.devel:
+
+class Viewer:
+    """Class for running the result viewer (viewer of found differences)."""
+    def __init__(self, compare_output_dir, devel):
+        """
+        :param compare_output_dir: Dir containing output of compare command.
+        :param devel: True to run viewer in development mode.
+        """
+        self.compare_output_dir = compare_output_dir
+        self.devel = devel
+        # Relative path of src files which were already copied to viewer dir.
+        self.processed_files = set()
+        # Path to snapshot directories.
+        self.old_snapshot_dir = None
+        self.new_snapshot_dir = None
+        # Loaded content of YAML which describes the found differences.
+        self.yaml_result = None
+        # Path to the viewer.
+        self.view_dir = None
+        # Path to the directory which viewer can access.
+        self.public_dir = None
+        # Path to the viewer dir containing data of the compared project.
+        self.data_dir = None
+        # Path to the viewer dir containing sources of the compared project.
+        self.source_dir = None
+        # Path to the viewer dir containing diff of functions.
+        self.diff_dir = None
+        # Path to the yaml (describing the result) in the viewer directory.
+        self.viewer_yaml_path = None
+
+    def run(self):
+        """Prepare and run the viewer."""
+        self._load_yaml()
+        self._get_snapshot_dirs()
+        self._get_viewer_dir()
+        self._prepare_dirs()
+        self._prepare_files_and_diffs()
+        self._start_server()
+        self._clean()
+
+    def _load_yaml(self):
+        """Load yaml which describes results."""
+        yaml_path = os.path.join(self.compare_output_dir, YAML_FILE_NAME)
+        if not os.path.exists(yaml_path):
             sys.stderr.write(
-                "Error: it is not possible to run the development server " +
-                "for installed DiffKemp\n")
+                f"ERROR: compare output is missing file '{YAML_FILE_NAME}'\n")
             sys.exit(errno.EINVAL)
-    # View directory does not exist
-    else:
-        sys.stderr.write(
-            "Error: the viewer was not found.\n" +
-            "The viewer was probably not installed.\n")
-        sys.exit(errno.ENOENT)
+        with open(yaml_path, "r") as file:
+            self.yaml_result = yaml.safe_load(file)
 
-    # Dir for storing necessary data for a visualisation of a compared project.
-    data_directory = os.path.join(public_directory, "data")
-    if not os.path.exists(data_directory):
-        os.mkdir(data_directory)
+    def _get_viewer_dir(self):
+        """Determine the viewer directory.
+        The manually built one has priority over the installed one."""
+        self.view_dir = os.path.join(os.path.dirname(__file__), "../view")
+        # Manually build one
+        if os.path.exists(self.view_dir):
+            if self.devel:
+                self.public_dir = os.path.join(self.view_dir, "public")
+            else:
+                self.public_dir = os.path.join(self.view_dir, "build")
+                if not os.path.isdir(self.public_dir):
+                    sys.stderr.write(
+                        "Could not find production build of the viewer.\n"
+                        "Use --devel to run a development server "
+                        "or execute CMake with -DBUILD_VIEWER=On.\n")
+                    sys.exit(errno.ENOENT)
+        # Installed one
+        elif os.path.exists(VIEW_INSTALL_DIR):
+            self.view_dir = VIEW_INSTALL_DIR
+            self.public_dir = VIEW_INSTALL_DIR
+            if self.devel:
+                sys.stderr.write(
+                    "Error: it is not possible to run the development server "
+                    "for installed DiffKemp\n")
+                sys.exit(errno.EINVAL)
+        # View directory does not exist
+        else:
+            sys.stderr.write(
+                "Error: the viewer was not found.\n"
+                "The viewer was probably not installed.\n")
+            sys.exit(errno.ENOENT)
 
-    # Preparing source directory
-    source_directory = os.path.join(data_directory, "src")
-    if not os.path.exists(source_directory):
-        os.mkdir(source_directory)
-    # Preparing diff directory
-    diff_directory = os.path.join(data_directory, "diffs")
-    if not os.path.exists(diff_directory):
-        os.mkdir(diff_directory)
+    def _prepare_dirs(self):
+        """Set and create subdirectories in the viewer directory."""
+        # Dir for storing necessary data for a visualisation.
+        self.data_dir = os.path.join(self.public_dir, "data")
+        if not os.path.exists(self.data_dir):
+            os.mkdir(self.data_dir)
+        # Preparing source directory
+        self.source_dir = os.path.join(self.data_dir, "src")
+        if not os.path.exists(self.source_dir):
+            os.mkdir(self.source_dir)
+        # Preparing diff directory
+        self.diff_dir = os.path.join(self.data_dir, "diffs")
+        if not os.path.exists(self.diff_dir):
+            os.mkdir(self.diff_dir)
 
-    # Prepare source and diff files to view directory
-    old_snapshot_dir = yaml_result["old-snapshot"]
-    new_snapshot_dir = yaml_result["new-snapshot"]
-    # Check if snapshot dirs exist
-    if not os.path.isdir(old_snapshot_dir):
-        sys.stderr.write(
-            f"Error: expecting to find old snapshot in {old_snapshot_dir}\n")
-        sys.exit(errno.EINVAL)
-    if not os.path.isdir(new_snapshot_dir):
-        sys.stderr.write(
-            f"Error: expecting to find new snapshot in {new_snapshot_dir}\n")
-        sys.exit(errno.EINVAL)
+    def _get_snapshot_dirs(self):
+        """Extract path to snapshot directories from the YAML."""
+        self.old_snapshot_dir = self.yaml_result["old-snapshot"]
+        self.new_snapshot_dir = self.yaml_result["new-snapshot"]
+        # Check if snapshot dirs exist
+        if not os.path.isdir(self.old_snapshot_dir):
+            sys.stderr.write("Error: expecting to find old snapshot in "
+                             f"{self.old_snapshot_dir}\n")
+            sys.exit(errno.EINVAL)
+        if not os.path.isdir(self.new_snapshot_dir):
+            sys.stderr.write("Error: expecting to find new snapshot in "
+                             f"{self.new_snapshot_dir}\n")
+            sys.exit(errno.EINVAL)
 
-    processed_files = set()
-    for name, definition in yaml_result["definitions"].items():
+    def _prepare_files_and_diffs(self):
+        """Prepare source and diff files to viewer directory."""
+        for name, definition in self.yaml_result["definitions"].items():
+            self._prepare_file_and_diff(name, definition)
+        # Save updated YAML to viewer directory.
+        self.viewer_yaml_path = os.path.join(self.data_dir, YAML_FILE_NAME)
+        with open(self.viewer_yaml_path, "w") as file:
+            yaml.dump(self.yaml_result, file, sort_keys=False)
+
+    def _prepare_file_and_diff(self, name, definition):
+        """
+        If possible create diff for symbol specified by `name` and described by
+        `definition`, update the YAML with info about the diff existence and
+        save the source file containing the symbol and the diff to viewer dir.
+        """
         # Relatives paths to source files
         old_file = definition["old"]["file"]
         new_file = definition["new"]["file"]
 
-        old_file_abs_path = os.path.join(old_snapshot_dir, old_file)
-        new_file_abs_path = os.path.join(new_snapshot_dir, new_file)
+        old_file_abs_path = os.path.join(self.old_snapshot_dir, old_file)
+        new_file_abs_path = os.path.join(self.new_snapshot_dir, new_file)
 
         # Copy source file
-        if old_file not in processed_files:
-            processed_files.add(old_file)
+        if old_file not in self.processed_files:
+            self.processed_files.add(old_file)
 
-            output_file_path = os.path.join(source_directory, old_file)
+            output_file_path = os.path.join(self.source_dir, old_file)
             output_dir_path = os.path.dirname(output_file_path)
             if not os.path.isdir(output_dir_path):
                 os.makedirs(output_dir_path)
@@ -712,44 +773,45 @@ def view(args):
             shutil.copy(old_file_abs_path, output_dir_path)
 
         # Make diff of function, add diff info to YAML
-        if "end-line" in definition["old"] and "end-line" in definition["new"]:
-            diff = unified_syntax_diff(first_file=old_file_abs_path,
-                                       second_file=new_file_abs_path,
-                                       first_line=definition["old"]["line"],
-                                       second_line=definition["new"]["line"],
-                                       first_end=definition["old"]["end-line"],
-                                       second_end=definition["new"]["end-line"]
-                                       )
+        if ("end-line" in definition["old"] and
+                "end-line" in definition["new"]):
+            diff = unified_syntax_diff(
+                first_file=old_file_abs_path,
+                second_file=new_file_abs_path,
+                first_line=definition["old"]["line"],
+                second_line=definition["new"]["line"],
+                first_end=definition["old"]["end-line"],
+                second_end=definition["new"]["end-line"])
             if diff.isspace() or diff == "":
                 definition["diff"] = False
             else:
                 definition["diff"] = True
-                diff_path = os.path.join(diff_directory, name + ".diff")
+                diff_path = os.path.join(self.diff_dir, name + ".diff")
                 with open(diff_path, "w") as file:
                     file.write(diff)
         else:
             definition["diff"] = False
 
-    # save YAML
-    with open(os.path.join(data_directory, YAML_FILE_NAME), "w") as file:
-        yaml.dump(yaml_result, file, sort_keys=False)
+    def _start_server(self):
+        """Start server with the viewer."""
+        if self.devel:
+            os.chdir(self.view_dir)
+            os.system("npm install")
+            os.system("npm start")
+        else:
+            os.chdir(self.public_dir)
+            handler = SimpleHTTPRequestHandler
+            handler.log_message = lambda *_, **__: None
+            with HTTPServer(("localhost", 3000), handler) as httpd:
+                print("Result viewer is available at http://localhost:3000")
+                print("Press Ctrl+C to exit")
+                try:
+                    httpd.serve_forever()
+                except KeyboardInterrupt:
+                    httpd.shutdown()
 
-    if args.devel:
-        os.chdir(view_directory)
-        os.system("npm install")
-        os.system("npm start")
-    else:
-        os.chdir(public_directory)
-        handler = SimpleHTTPRequestHandler
-        handler.log_message = lambda *_, **__: None
-        with HTTPServer(("localhost", 3000), handler) as httpd:
-            print("Result viewer is available at http://localhost:3000")
-            print("Press Ctrl+C to exit")
-            try:
-                httpd.serve_forever()
-            except KeyboardInterrupt:
-                httpd.shutdown()
-    # Cleaning
-    shutil.rmtree(source_directory)
-    shutil.rmtree(diff_directory)
-    os.remove(os.path.join(data_directory, YAML_FILE_NAME))
+    def _clean(self):
+        """Clean directories."""
+        shutil.rmtree(self.source_dir)
+        shutil.rmtree(self.diff_dir)
+        os.remove(self.viewer_yaml_path)


### PR DESCRIPTION
Because the function for `view` command is getting long and #314 would add more logic (copying src files also for the new version of the compared project) I thought it could be better if I first refactor the function  - split it into multiple methods of a class. More information is in the commit message.