### PR TITLE
Viewer: preparation of macro visualisation

### DIFF
--- a/view/src/PropTypesValues.js
+++ b/view/src/PropTypesValues.js
@@ -15,7 +15,7 @@ export const DiffPropTypes = PropTypes.shape({
 });
 
 const DefinitionShape = {
-  kind: PropTypes.oneOf(['function', 'type']),
+  kind: PropTypes.oneOf(['function', 'type', 'macro']),
   old: PropTypes.shape({
     line: PropTypes.number,
     file: PropTypes.string,

--- a/view/src/components/Callstack.jsx
+++ b/view/src/components/Callstack.jsx
@@ -6,13 +6,29 @@ import { PropTypes } from 'prop-types';
 import { CallstackPropTypes, DefinitionsPropTypes } from '../PropTypesValues';
 
 /**
+ * Enum representing in which call stack is the call located.
+ */
+export const CallSide = Object.freeze({
+  BOTH: 'both',
+  NEW: 'new',
+  OLD: 'old',
+});
+
+const SelectedFunPropType = PropTypes.shape({
+  name: PropTypes.string,
+  side: PropTypes.oneOf(Object.values(CallSide)),
+});
+
+/**
  * Component for visualisation of call stack.
  * @param {Object} props
  * @param {string} props.compFunName - First (compared) function name.
- * @param {string} props.selectedFunction - Name of function which is selected
- * and should be highlighted in call stack.
- * @param {Function} props.onSelect - Callback function accepting a function
- * name which was chosen to be shown.
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {string} props.selectedFunction.name - Name of the selected function.
+ * @param {string} props.selectedFunction.side - The side where the selected function is located.
+ * @param {Function} props.onSelect - Callback function accepting a selected function,
+ *   the callback is called when call (function) is clicked (selected).
  * @returns Returns call stack component.
  */
 export default function Callstack({
@@ -133,7 +149,7 @@ Callstack.propTypes = {
   compFunName: PropTypes.string.isRequired,
   oldCallStack: CallstackPropTypes.isRequired,
   newCallStack: CallstackPropTypes.isRequired,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
   definitions: DefinitionsPropTypes.isRequired,
 };
@@ -143,9 +159,9 @@ Callstack.propTypes = {
  * @param {Object} props
  * @param {string} props.oldName - Name of old call (function).
  * @param {string} props.newName - Name of new call (function).
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
  * @returns
  */
 function SingleCall({
@@ -160,6 +176,7 @@ function SingleCall({
         name={oldName}
         onSelect={onSelect}
         selectedFunction={selectedFunction}
+        side={CallSide.BOTH}
       />
     );
   }
@@ -176,7 +193,7 @@ function SingleCall({
 SingleCall.propTypes = {
   oldName: PropTypes.string.isRequired,
   newName: PropTypes.string,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
 };
 
@@ -186,9 +203,9 @@ SingleCall.propTypes = {
  * @param {Object} props
  * @param {Object[]} props.oldCalls - Calls from old call stack.
  * @param {Object[]} props.newCalls - Calls from new call stack.
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
  * @returns
  */
 function Calls({
@@ -204,6 +221,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
+            side={CallSide.OLD}
           />
         ))}
       </ListGroup>
@@ -215,6 +233,7 @@ function Calls({
             name={call.name}
             onSelect={onSelect}
             selectedFunction={selectedFunction}
+            side={CallSide.NEW}
           />
         ))}
       </ListGroup>
@@ -225,7 +244,7 @@ function Calls({
 Calls.propTypes = {
   oldCalls: CallstackPropTypes.isRequired,
   newCalls: CallstackPropTypes,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
 };
 
@@ -233,12 +252,18 @@ Calls.propTypes = {
  * Component for visualisation of call from call stack.
  * @param {Object} props
  * @param {string} props.name - Name of called function/macro/type.
- * @param {string} props.selectedFunction - Name of selected function.
- * @param {Function} props.onSelect - Callback function which is called
- * when call (function) is clicked (selected).
+ * @param {Object} props.selectedFunction - Function which is selected and should
+ *   be highlighted in the call stack.
+ * @param {Function} props.onSelect - Callback function accepting a selected function.
+ * @param {string} props.side - The side where the call is located.
  * @returns
  */
-function Call({ name, selectedFunction, onSelect }) {
+function Call({
+  name,
+  selectedFunction,
+  onSelect,
+  side,
+}) {
   // putting information about type/macro under the name of function
   const nameWrap = name.replace(' ', '<br/>');
   return (
@@ -247,8 +272,8 @@ function Call({ name, selectedFunction, onSelect }) {
       title={name}
       action
       className="callstack-call"
-      onClick={() => onSelect(name)}
-      active={name === selectedFunction}
+      onClick={() => onSelect({ name, side })}
+      active={name === selectedFunction?.name && side === selectedFunction?.side}
       dangerouslySetInnerHTML={{ __html: nameWrap }}
     />
   );
@@ -256,6 +281,7 @@ function Call({ name, selectedFunction, onSelect }) {
 
 Call.propTypes = {
   name: PropTypes.string.isRequired,
-  selectedFunction: PropTypes.string,
+  selectedFunction: SelectedFunPropType,
   onSelect: PropTypes.func.isRequired,
+  side: PropTypes.oneOf(Object.values(CallSide)),
 };

--- a/view/src/components/Code.jsx
+++ b/view/src/components/Code.jsx
@@ -12,7 +12,10 @@ import Col from 'react-bootstrap/Col';
 
 import DiffViewWrapper from './DiffViewWrapper';
 
-const SOURCE_DIRECTORY = 'src';
+// Directories with compared project sources.
+const OLD_SRC_DIR = 'src-old';
+// eslint-disable-next-line no-unused-vars
+const NEW_SRC_DIR = 'src-new';
 const DIFF_DIRECTORY = 'diffs';
 
 /**
@@ -49,7 +52,7 @@ export default function Code({
 
     const getOldCode = async () => {
       const oldCodeFile = await getFile(
-        path.join(SOURCE_DIRECTORY, specification.oldSrc),
+        path.join(OLD_SRC_DIR, specification.oldSrc),
       );
       if (ignoreFetchedFiles) return;
       setOldCode(oldCodeFile);

--- a/view/src/components/Code.jsx
+++ b/view/src/components/Code.jsx
@@ -36,7 +36,9 @@ const DIFF_DIRECTORY = 'diffs';
  *                                              of the function ends.
  * @param {Number} [props.specification.calling] - Tuple (old, new) of line numbers where are called
  *                                                 next functions which should be highlighted
- *                                                 or undefined if it is differing function.
+ *                                                 or undefined if no functions are called.
+ * @param {boolean} props.specification.differing - True if the symbol is the differing one
+ *                                                  and the syntax difference should be highlighted.
  * @param {string} props.oldFolder - Name of snapshot folder with old version of project.
  * @param {string} props.newFolder - Name of snapshot folder with new version of project.
  * @param {Function} props.getFile - Function for getting file.
@@ -124,7 +126,7 @@ export default function Code({
             newStart={specification.newStart}
             oldEnd={specification.oldEnd}
             newEnd={specification.newEnd}
-            showDiff={specification.calling === undefined}
+            showDiff={specification.differing}
             linesToShow={specification.calling === undefined
               ? null
               : specification.calling}
@@ -145,6 +147,7 @@ Code.propTypes = {
     oldEnd: PropTypes.number,
     newEnd: PropTypes.number,
     calling: PropTypes.arrayOf(PropTypes.number),
+    differing: PropTypes.bool,
   }).isRequired,
   oldFolder: PropTypes.string.isRequired,
   newFolder: PropTypes.string.isRequired,

--- a/view/src/components/Code.jsx
+++ b/view/src/components/Code.jsx
@@ -14,14 +14,16 @@ import DiffViewWrapper from './DiffViewWrapper';
 
 // Directories with compared project sources.
 const OLD_SRC_DIR = 'src-old';
-// eslint-disable-next-line no-unused-vars
 const NEW_SRC_DIR = 'src-new';
 const DIFF_DIRECTORY = 'diffs';
 
 /**
- * Code/function preparation and visualisation.
+ * Preparation (file content fetching) and visualisation of a code of a function.
+ * Function refers generally to symbol definition, including functions, types and macros.
  * @param {Object} props
  * @param {Object} props.specification - Specification of code to be shown.
+ *   If only one version (old/new) is supposed to be shown then the fields
+ *   for the other version should be null.
  * @param {string} props.specification.oldSrc - Path to the source file in which
  *                                              is located old version of function.
  * @param {string} props.specification.newSrc - Path to source file of the
@@ -43,19 +45,29 @@ const DIFF_DIRECTORY = 'diffs';
 export default function Code({
   specification, oldFolder, newFolder, getFile,
 }) {
+  // Content of source files containing function definition.
   const [oldCode, setOldCode] = useState(null);
+  const [newCode, setNewCode] = useState(null);
+  // Diff of the function definition.
   const [diff, setDiff] = useState(null);
   // Getting content of source and diff file.
   useEffect(() => {
     // variable for handling race conditions
     let ignoreFetchedFiles = false;
-
+    // Functions for fetching content of the source files.
     const getOldCode = async () => {
       const oldCodeFile = await getFile(
         path.join(OLD_SRC_DIR, specification.oldSrc),
       );
       if (ignoreFetchedFiles) return;
       setOldCode(oldCodeFile);
+    };
+    const getNewCode = async () => {
+      const newCodeFile = await getFile(
+        path.join(NEW_SRC_DIR, specification.newSrc),
+      );
+      if (ignoreFetchedFiles) return;
+      setNewCode(newCodeFile);
     };
     const getDiff = async () => {
       const diffFile = await getFile(
@@ -66,7 +78,12 @@ export default function Code({
     };
 
     if (specification) {
-      getOldCode();
+      // Get source code of the file in which is the specified function located.
+      if (specification.oldSrc) getOldCode();
+      else setOldCode('');
+      if (specification.newSrc) getNewCode();
+      else setNewCode('');
+
       if (specification.diff) {
         getDiff();
       } else {
@@ -78,15 +95,15 @@ export default function Code({
     };
   }, [specification, getFile]);
 
-  if (oldCode === null || diff == null) {
+  if (oldCode === null || newCode === null || diff == null) {
     return null;
   }
   return (
     <div>
       {/* showing info about location of file */}
       <Row className="py-2 border border-primary rounded-top text-bg-primary">
-        <Col>{path.join(oldFolder, specification.oldSrc)}</Col>
-        <Col>{path.join(newFolder, specification.newSrc)}</Col>
+        <Col>{specification.oldSrc && path.join(oldFolder, specification.oldSrc)}</Col>
+        <Col>{specification.newSrc && path.join(newFolder, specification.newSrc)}</Col>
       </Row>
       {/* showing code of function */}
       <Row className="border border-primary rounded-bottom p-1">
@@ -101,10 +118,12 @@ export default function Code({
         >
           <DiffViewWrapper
             oldCode={oldCode}
+            newCode={newCode}
             diff={diff}
             oldStart={specification.oldStart}
             newStart={specification.newStart}
             oldEnd={specification.oldEnd}
+            newEnd={specification.newEnd}
             showDiff={specification.calling === undefined}
             linesToShow={specification.calling === undefined
               ? null
@@ -118,12 +137,13 @@ export default function Code({
 
 Code.propTypes = {
   specification: PropTypes.shape({
-    oldSrc: PropTypes.string.isRequired,
-    newSrc: PropTypes.string.isRequired,
+    oldSrc: PropTypes.string,
+    newSrc: PropTypes.string,
     diff: PropTypes.string,
-    oldStart: PropTypes.number.isRequired,
-    newStart: PropTypes.number.isRequired,
-    oldEnd: PropTypes.number.isRequired,
+    oldStart: PropTypes.number,
+    newStart: PropTypes.number,
+    oldEnd: PropTypes.number,
+    newEnd: PropTypes.number,
     calling: PropTypes.arrayOf(PropTypes.number),
   }).isRequired,
   oldFolder: PropTypes.string.isRequired,

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -9,7 +9,7 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import Alert from 'react-bootstrap/Alert';
 
-import Callstack from './Callstack';
+import Callstack, { CallSide } from './Callstack';
 import Code from './Code';
 import { DefinitionsPropTypes, DiffPropTypes } from '../PropTypesValues';
 
@@ -30,20 +30,32 @@ export default function Difference({
   definitions,
   getFile,
 }) {
-  // name of function to be shown (defaultly showing differing function)
-  const [functionToShow, setFunctionToShow] = useState(
-    diff['old-callstack'].length > 0
+  // Function which code to show (defaultly showing the differing function).
+  const [functionToShow, setFunctionToShow] = useState({
+    // If there is no call stack, the differing function is the compared function.
+    name: diff['old-callstack'].length > 0
       ? diff['old-callstack'][diff['old-callstack'].length - 1].name
       : compare,
-  );
+    // The differing function should be located in both call stacks.
+    side: CallSide.BOTH,
+  });
   let codeBlock = null;
   let errorCodeMessage = null;
   // extracting only name (putting away kind)
-  const name = functionToShow.split(' ')[0];
+  const name = functionToShow.name.split(' ')[0];
+  // Extracting on which side is the call located.
+  const { side } = functionToShow;
 
-  if (name in definitions) {
-    const oldDefintion = definitions[name].old;
-    const newDefintion = definitions[name].new;
+  const needsOldCode = (side === CallSide.BOTH || side === CallSide.OLD);
+  const needsNewCode = (side === CallSide.BOTH || side === CallSide.NEW);
+  const containsDefinition = (name in definitions);
+  const containsOldDef = containsDefinition && 'old' in definitions[name];
+  const containsNewDef = containsDefinition && 'new' in definitions[name];
+  // If we need old/new code then it has to contain old/new defintion.
+  // Note: implication X => Y <=> not X or Y
+  if ((!needsOldCode || containsOldDef) && (!needsNewCode || containsNewDef)) {
+    const oldDefintion = definitions[name]?.old;
+    const newDefintion = definitions[name]?.new;
 
     // returns line where is called next function in callstack
     // or undefined if it is differing function
@@ -51,12 +63,12 @@ export default function Difference({
       // indexes to callstack containing called function
       let oldIndex = 0;
       let newIndex = 0;
-      if (functionToShow !== compare) {
+      if (functionToShow.name !== compare) {
         oldIndex = diff['old-callstack'].findIndex(
-          (call) => call.name === functionToShow,
+          (call) => call.name === functionToShow.name,
         ) + 1;
         newIndex = diff['new-callstack'].findIndex(
-          (call) => call.name === functionToShow,
+          (call) => call.name === functionToShow.name,
         ) + 1;
       }
 
@@ -71,26 +83,27 @@ export default function Difference({
       }
       return undefined;
     };
-    if (!('end-line' in oldDefintion) || !('end-line' in newDefintion)) {
+    if ((needsOldCode && !('end-line' in oldDefintion))
+        || (needsNewCode && !('end-line' in newDefintion))) {
       errorCodeMessage = 'Missing info about ending of function.';
     } else {
       // creating component for code visualisation
       // if all information are included for showing code of function
       const specification = {
-        oldSrc: oldDefintion.file,
-        newSrc: newDefintion.file,
-        diff: definitions[name].diff
+        oldSrc: needsOldCode ? oldDefintion.file : null,
+        newSrc: needsNewCode ? newDefintion.file : null,
+        diff: side === CallSide.BOTH && definitions[name].diff
           ? `${name}.diff`
           : null,
-        oldStart: oldDefintion.line,
-        newStart: newDefintion.line,
-        oldEnd: oldDefintion['end-line'],
-        newEnd: newDefintion['end-line'],
+        oldStart: needsOldCode ? oldDefintion.line : null,
+        newStart: needsNewCode ? newDefintion.line : null,
+        oldEnd: needsOldCode ? oldDefintion['end-line'] : null,
+        newEnd: needsNewCode ? newDefintion['end-line'] : null,
         calling: getCallingLine(),
       };
       codeBlock = (
         <Code
-          key={`${compare}-${functionToShow}`}
+          key={`${compare}-${name}`}
           specification={specification}
           getFile={getFile}
           oldFolder={oldFolder}
@@ -98,7 +111,7 @@ export default function Difference({
         />
       );
     }
-  } /* if (name in definitions) */ else {
+  } else {
     errorCodeMessage = 'Missing info about definitions of functions.';
   }
 

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -1,7 +1,7 @@
 // Component for visualisation of found difference
 // Author: Lukas Petr
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { PropTypes } from 'prop-types';
 
 import Container from 'react-bootstrap/Container';
@@ -30,12 +30,23 @@ export default function Difference({
   definitions,
   getFile,
 }) {
+  // Name (with kind) of differing symbol.
+  const [oldDiffering, newDiffering] = useMemo(() => {
+    let oldD;
+    let newD;
+    if (diff['old-callstack'].length > 0) {
+      oldD = diff['old-callstack'][diff['old-callstack'].length - 1].name;
+      newD = diff['new-callstack'][diff['new-callstack'].length - 1].name;
+    } else {
+      // If there is no call stack, the differing function is the compared function.
+      oldD = compare;
+      newD = compare;
+    }
+    return [oldD, newD];
+  }, [diff, compare]);
   // Function which code to show (defaultly showing the differing function).
   const [functionToShow, setFunctionToShow] = useState({
-    // If there is no call stack, the differing function is the compared function.
-    name: diff['old-callstack'].length > 0
-      ? diff['old-callstack'][diff['old-callstack'].length - 1].name
-      : compare,
+    name: oldDiffering,
     // The differing function should be located in both call stacks.
     side: CallSide.BOTH,
   });
@@ -100,6 +111,7 @@ export default function Difference({
         oldEnd: needsOldCode ? oldDefintion['end-line'] : null,
         newEnd: needsNewCode ? newDefintion['end-line'] : null,
         calling: getCallingLine(),
+        differing: [oldDiffering, newDiffering].includes(functionToShow.name),
       };
       codeBlock = (
         <Code

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -85,6 +85,7 @@ export default function Difference({
         oldStart: oldDefintion.line,
         newStart: newDefintion.line,
         oldEnd: oldDefintion['end-line'],
+        newEnd: newDefintion['end-line'],
         calling: getCallingLine(),
       };
       codeBlock = (

--- a/view/src/components/Difference.jsx
+++ b/view/src/components/Difference.jsx
@@ -110,9 +110,13 @@ export default function Difference({
         newStart: needsNewCode ? newDefintion.line : null,
         oldEnd: needsOldCode ? oldDefintion['end-line'] : null,
         newEnd: needsNewCode ? newDefintion['end-line'] : null,
-        calling: getCallingLine(),
         differing: [oldDiffering, newDiffering].includes(functionToShow.name),
       };
+      // If the selected symbol is a function, get the line on which is called
+      // next symbol from the call stack.
+      if (definitions[name].kind === 'function') {
+        specification.calling = getCallingLine();
+      }
       codeBlock = (
         <Code
           key={`${compare}-${name}`}

--- a/view/src/tests/DiffViewWrapper.test.jsx
+++ b/view/src/tests/DiffViewWrapper.test.jsx
@@ -8,6 +8,7 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
 import DiffViewWrapper from '../components/DiffViewWrapper';
+import Difference from '../components/Difference';
 
 /**
  * Helper function to test if shown line number and line of code match
@@ -231,6 +232,7 @@ describe('testing a caller function visualisation', () => {
   const oldStart = 176;
   const newStart = 180;
   const oldEnd = 197;
+  const newEnd = 201;
   const calling = [190, 194];
 
   const diff = '';
@@ -320,5 +322,107 @@ describe('testing a caller function visualisation', () => {
       () => {},
       () => {},
     );
+  });
+
+  // Integration testing from Difference component.
+  test('code of calls which are only on one side of call stack should be visualised correctly', async () => {
+    // Note: For these calls should be shown code of the function/macro and it should
+    // be shown on correct side (left/right), the other side should be left empty.
+
+    // Note: Reusing parts from previous test case.
+    const example = {
+      results: [{
+        // compared function
+        function: 'cmp_fun',
+        diffs: [{
+          // differing macro
+          function: 'diff',
+          'old-callstack': [
+            { name: 'left (macro)', line: 5, file: 'file1.c' },
+            { name: 'diff (macro)', line: oldStart, file: 'left_file.c' },
+          ],
+          'new-callstack': [
+            { name: 'right (macro)', line: 5, file: 'file1.c' },
+            { name: 'diff (macro)', line: newStart, file: 'right_file.c' },
+          ],
+        }],
+      }],
+      definitions: {
+        left: {
+          kind: 'macro',
+          old: { line: oldStart, file: 'left_file.c', 'end-line': oldEnd },
+          diff: false,
+        },
+        right: {
+          kind: 'macro',
+          new: { line: newStart, file: 'right_file.c', 'end-line': newEnd },
+          diff: false,
+        },
+      },
+    };
+
+    // Mocking getFile to return the content of the file.
+    const getFile = jest.fn(async (filePath) => {
+      let content = filePath;
+      if (filePath === 'src-old/left_file.c') {
+        content = oldCode;
+      } else if (filePath === 'src-new/right_file.c') {
+        content = newCode;
+      }
+      return content;
+    });
+
+    render(
+      <Difference
+        compare={example.results[0].function}
+        diff={example.results[0].diffs[0]}
+        definitions={example.definitions}
+        getFile={getFile}
+        oldFolder=""
+        newFolder=""
+      />,
+    );
+
+    const callstack = within(screen.getByTestId('callstack'));
+
+    // Selecting function which is only in the old call stack.
+    userEvent.click(callstack.getByTitle('left (macro)'));
+    // Waiting for update.
+    await screen.findByText(/left_file.c/);
+    // Testing that the whole code of the function is shown
+    // and it is shown on the left side and the right side is empty.
+    let expectedOldLineNum = oldStart;
+    testCodeNumberMatch(
+      oldCode,
+      '',
+      // Testing order of lines and checking whether any are missing.
+      (lineNumber) => {
+        expect(lineNumber).toBe(expectedOldLineNum);
+        expectedOldLineNum += 1;
+      },
+      () => {},
+    );
+    // Testing if the whole function is shown.
+    expect(expectedOldLineNum).toBe(oldEnd + 1);
+
+    // Selecting function which is only in the new call stack.
+    userEvent.click(callstack.getByTitle('right (macro)'));
+    // Waiting for update.
+    await screen.findByText(/right_file.c/);
+    // Testing that the whole code of the function is shown
+    // and it is shown on the right side and the left side is empty.
+    let expectedNewLineNum = newStart;
+    testCodeNumberMatch(
+      '',
+      newCode,
+      () => {},
+      // Testing order of lines and checking whether any are missing.
+      (lineNumber) => {
+        expect(lineNumber).toBe(expectedNewLineNum);
+        expectedNewLineNum += 1;
+      },
+    );
+    // Testing if the whole function is shown.
+    expect(expectedNewLineNum).toBe(newEnd + 1);
   });
 });

--- a/view/src/tests/Difference.test.jsx
+++ b/view/src/tests/Difference.test.jsx
@@ -121,10 +121,12 @@ test('first shown function should be differing function', async () => {
     expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
       expect.objectContaining({
         oldCode: 'src-old/include/linux/sched.h',
+        newCode: 'src-new/include/linux/sched.h',
         diff: 'diffs/task_struct.diff',
         oldStart: 594,
         newStart: 594,
         oldEnd: 1217,
+        newEnd: 1261,
         showDiff: true,
         linesToShow: null,
       }),
@@ -153,10 +155,12 @@ describe('after click on function in callstack', () => {
       expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
         expect.objectContaining({
           oldCode: 'src-old/kernel/pid.c',
+          newCode: 'src-new/kernel/pid.c',
           diff: '',
           oldStart: 438,
           newStart: 443,
           oldEnd: 441,
+          newEnd: 446,
           showDiff: false,
           linesToShow: [440, 445],
         }),

--- a/view/src/tests/Difference.test.jsx
+++ b/view/src/tests/Difference.test.jsx
@@ -120,7 +120,7 @@ test('first shown function should be differing function', async () => {
   await waitFor(() => {
     expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        oldCode: 'src/include/linux/sched.h',
+        oldCode: 'src-old/include/linux/sched.h',
         diff: 'diffs/task_struct.diff',
         oldStart: 594,
         newStart: 594,
@@ -152,7 +152,7 @@ describe('after click on function in callstack', () => {
     await waitFor(() => {
       expect(mockPropsDiffViewWrapper).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          oldCode: 'src/kernel/pid.c',
+          oldCode: 'src-old/kernel/pid.c',
           diff: '',
           oldStart: 438,
           newStart: 443,


### PR DESCRIPTION
This PR contains the next set of commits from #314. It prepares the viewer for visualisation of macros, it enables to show code of macros that are located only on one side of a call stack.

The main changes are:
- Previously, we copied only the sources of old version of the compared program,. This PR adds copying of the new project version sources to the folder accessible by the viewer.
- Updates in the `Callstack` component to indicate whether the selected call from the call stack is located in the left, right, or both call stacks. This helps to show the correct version of the code (code for old/new/both versions).
- Enhancements of `DiffViewWrapper` component (component for rendering the code) so it to allow it to show code for only old/new version.
- Because from call stack information we are unable to deduce for macros on which line is used the next macro (lines are present in the call stack but they do not represent line where the macro is used but line where the parent macro definition starts),  the last 3 commits ensure that the entire macro definition is shown without highlighting the incorrect line.

This PR only prepares the visualisation but does not add macro definitions to `diffkemp-out.yaml` (created by `compare` command). So the viewer is able to show the macros, but currently, it does not have the necessary information for that (the macro definitions). I will open another PR which will add the macro definitions to `diffkemp-out.yaml after this PR is merged.
If this PR would be too much to review I could split it into more PRs based on commits.

Screenshots of code visualisation of macros:
- Same macro in both call stacks:
  ![image](https://github.com/diffkemp/diffkemp/assets/80856731/52603ec8-8979-4a23-9044-0696c6ce6a99)
- Macro located only in left/old call stack:
  ![image](https://github.com/diffkemp/diffkemp/assets/80856731/4ed94206-70d1-4ec3-9864-baa83a4ecdc1)
- Macro located only in right/new call stack:
  ![image](https://github.com/diffkemp/diffkemp/assets/80856731/b62f9a07-374e-4574-8ba2-43ec7ff8bc2c)
- Macro in which was found difference:
  ![image](https://github.com/diffkemp/diffkemp/assets/80856731/8c21f3d8-68a4-44c5-a809-fdc6b0b264d9)
