### PR TITLE
Refactoring: `CallInfo` and `FunctionInfo` to be using `CodeLocation`

### DIFF
--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -181,13 +181,13 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                 if (calledFirst)
                     for (const CallInfo &CI :
                          ComparedFuns.at({FirstFun, SecondFun}).First.calls) {
-                        if (CI.fun == calledFirst->getName().str())
+                        if (CI.name == calledFirst->getName().str())
                             CI.weak = true;
                     }
                 if (calledSecond)
                     for (const CallInfo &CI :
                          ComparedFuns.at({FirstFun, SecondFun}).Second.calls) {
-                        if (CI.fun == calledSecond->getName().str())
+                        if (CI.name == calledSecond->getName().str())
                             CI.weak = true;
                     }
             }

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -23,7 +23,7 @@ namespace llvm {
 namespace yaml {
 template <> struct MappingTraits<CallInfo> {
     static void mapping(IO &io, CallInfo &callinfo) {
-        io.mapRequired("function", callinfo.fun);
+        io.mapRequired("function", callinfo.name);
         io.mapRequired("file", callinfo.file);
         io.mapRequired("line", callinfo.line);
         io.mapRequired("weak", callinfo.weak);

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -74,7 +74,7 @@ namespace yaml {
 template <> struct MappingTraits<std::unique_ptr<CodeLocation>> {
     static void mapping(IO &io, std::unique_ptr<CodeLocation> &loc) {
         io.mapRequired("name", loc->name);
-        io.mapRequired("file", loc->sourceFile);
+        io.mapRequired("file", loc->file);
         io.mapRequired("line", loc->line);
     }
 };

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -24,6 +24,22 @@
 
 using namespace llvm;
 
+/// Type for storing information about code location of an 'object'
+/// (eg. location of a function or a macro definition).
+struct CodeLocation {
+    // Name of the 'object'.
+    std::string name;
+    // Line in the file.
+    unsigned line;
+    // A C source file name.
+    std::string file;
+    CodeLocation() = default;
+    CodeLocation(const std::string &name,
+                 unsigned line,
+                 const std::string &file)
+            : name(name), line(line), file(file) {}
+};
+
 /// Encapsulates statistics about analysis of a single function.
 struct FunctionStats {
     unsigned instCnt = 0;
@@ -55,10 +71,7 @@ typedef std::vector<CallInfo> CallStack;
 /// Type for information about a single function. Contains the function name,
 /// definition location (file and line), and a list of called functions (in the
 /// form of a set of CallInfo objects).
-struct FunctionInfo {
-    std::string name;
-    std::string file;
-    int line;
+struct FunctionInfo : public CodeLocation {
     FunctionStats stats;
     std::set<CallInfo> calls;
 
@@ -67,9 +80,9 @@ struct FunctionInfo {
     FunctionInfo() {}
     FunctionInfo(const std::string &name,
                  const std::string &file,
-                 int line,
+                 unsigned line,
                  std::set<CallInfo> calls = {})
-            : name(name), file(file), line(line), calls(std::move(calls)) {}
+            : CodeLocation(name, line, file), calls(std::move(calls)) {}
 
     /// Add a new function call.
     /// @param Callee Called function.
@@ -77,20 +90,6 @@ struct FunctionInfo {
     void addCall(const Function *Callee, int l) {
         calls.insert(CallInfo(Callee->getName().str(), file, l));
     }
-};
-
-/// Type for storing information about code location of an 'object'
-/// (eg. location of macro definition).
-struct CodeLocation {
-    // Name of the 'object'.
-    std::string name;
-    // Line in the sourceFile.
-    unsigned line;
-    // A C source file name.
-    std::string sourceFile;
-    CodeLocation() = default;
-    CodeLocation(std::string name, unsigned line, std::string sourceFile)
-            : name(name), line(line), sourceFile(sourceFile) {}
 };
 
 /// Generic type for non-function differences.

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -50,19 +50,16 @@ struct FunctionStats {
     FunctionStats() {}
 };
 
-/// Type for function call information: contains the called function and its
-/// call location (file and line).
-struct CallInfo {
-    std::string fun;
-    std::string file;
-    unsigned line;
+/// Type for function call information: contains the called function name and
+/// its call location (file and line).
+struct CallInfo : public CodeLocation {
     mutable bool weak;
 
     // Default constructor needed for YAML serialisation.
     CallInfo() {}
-    CallInfo(const std::string &fun, const std::string &file, unsigned int line)
-            : fun(fun), file(file), line(line), weak(false) {}
-    bool operator<(const CallInfo &Rhs) const { return fun < Rhs.fun; }
+    CallInfo(const std::string &name, const std::string &file, unsigned line)
+            : CodeLocation(name, line, file), weak(false) {}
+    bool operator<(const CallInfo &Rhs) const { return name < Rhs.name; }
 };
 
 /// Call stack - list of call entries

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -93,7 +93,7 @@ void MacroDiffAnalysis::collectMacroUsesAtLocation(
                                                ? parentMacroUse->def->line
                                                : Loc->getLine();
                     newMacroUse.sourceFile =
-                            parentMacroUse ? parentMacroUse->def->sourceFile
+                            parentMacroUse ? parentMacroUse->def->file
                                            : getSourceFilePath(Loc->getScope());
 
                     // Retrieve macro arguments
@@ -375,7 +375,7 @@ void MacroDiffAnalysis::collectMacroDefs(DICompileUnit *CompileUnit) {
                 element.name = macroName;
                 element.fullName = Macro->getName().str();
                 element.body = Macro->getValue();
-                element.sourceFile = MF->getFile()->getFilename().str();
+                element.file = MF->getFile()->getFilename().str();
                 element.line = Macro->getLine();
 
                 if (element.fullName.find('(') != std::string::npos) {

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -287,14 +287,14 @@ std::vector<std::unique_ptr<SyntaxDifference>>
             LOG_VERBOSE_EXTRA("Left stack:\n\t");
             LOG_VERBOSE_EXTRA(MacroUseL.second.def->body << "\n");
             for (CallInfo &elem : StackL) {
-                LOG_VERBOSE_EXTRA("\t\tfrom " << elem.fun << " in file "
+                LOG_VERBOSE_EXTRA("\t\tfrom " << elem.name << " in file "
                                               << elem.file << " on line "
                                               << elem.line << "\n");
             }
             LOG_VERBOSE_EXTRA("Right stack:\n\t");
             LOG_VERBOSE_EXTRA(MacroUseR->second.def->body << "\n");
             for (CallInfo &elem : StackR) {
-                LOG_VERBOSE_EXTRA("\t\tfrom " << elem.fun << " in file "
+                LOG_VERBOSE_EXTRA("\t\tfrom " << elem.name << " in file "
                                               << elem.file << " on line "
                                               << elem.line << "\n");
             };


### PR DESCRIPTION
In PR #333, the `CodeLocation` struct was created to encapsulate information about code location (name of symbol, line, and file on which the symbol appears). This PR refactors  `CallInfo` and `FunctionInfo` structs, which previously contained the `name`, `line`, and `file` fields, to now extend the `CodeLocation` struct.