### PR TITLE
Iterate over phisToCompare based on size

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -54,9 +54,17 @@ int DifferentialFunctionComparator::compare() {
         return 1;
     }
     if (Res == 0) {
-        for (auto &PhiPair : phisToCompare)
+        // Size-based for-loop is intentionally used instead of range-based,
+        // since new elements may be inserted into the array during iteration
+        // (e.g., when the result of one PHI node is used inside another
+        // PHI node -- the first PHI is not present in phisToCompare since its
+        // only user was skipped and the operands were not analyzed).
+        // We need to analyze all the PHI nodes, even such PHI chains.
+        for (unsigned i = 0; i < phisToCompare.size(); i++) {
+            auto PhiPair = phisToCompare[i];
             if (cmpPHIs(PhiPair.first, PhiPair.second))
                 return 1;
+        }
         // Functions are equal so we don't have differing instructions
         DifferingInstructions = {nullptr, nullptr};
         return 0;


### PR DESCRIPTION
Range-based for-loops do not iterate over elements that get added during iteration, e.g., by using .emplace_back(). This could have caused a false negative when comparing program with a specific arrangment of PHI nodes, e.g., when the result of one PHI is used directly inside another PHI. In this case, the first PHI is not present in the phisToCompare vector (its only user was skipped during analysis) but must be compared nonetheless. In this case, the first PHI is inserted during cmpPHIs, i.e., while iterating over phisToCompare. We must therefore consider even such PHI chains and support insertion during iteration.