### PR TITLE
SimpLL: run GVN pass after inlining

### DIFF
--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -17,6 +17,7 @@
 #include "DebugInfo.h"
 #include <algorithm>
 #include <iostream>
+#include <llvm/Analysis/AliasAnalysis.h>
 #include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/DebugInfo.h>
@@ -31,6 +32,7 @@
 #include <llvm/Support/Path.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Scalar/DCE.h>
+#include <llvm/Transforms/Scalar/NewGVN.h>
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <numeric>
@@ -293,9 +295,11 @@ void simplifyFunction(Function *Fun) {
     PassBuilder pb;
     FunctionPassManager fpm;
     FunctionAnalysisManager fam;
+    fam.registerPass([] { return AAManager(); });
     pb.registerFunctionAnalyses(fam);
     fpm.addPass(SimplifyCFGPass{});
     fpm.addPass(DCEPass{});
+    fpm.addPass(NewGVNPass{});
     fpm.run(*Fun, fam);
 }
 

--- a/tests/regression/test_specs/rhel-81-82.yaml
+++ b/tests/regression/test_specs/rhel-81-82.yaml
@@ -1,0 +1,5 @@
+old_kernel: kernel/linux-4.18.0-147.el8
+new_kernel: kernel/linux-4.18.0-193.el8
+
+functions:
+  __rmqueue_smallest: equal


### PR DESCRIPTION
Run "Global Variable Numbering" pass after inlining functions. This eliminates redundant instructions, for example helps with the following scenario:
    
Old version:
```llvm
void foo(%0) {
  %1 = getelementptr %0, 0, 9
  %2 = load %1
  call bar(%2)
}
```
New version:
```llvm
void foo(%0) {
  %1 = getelementptr %0, 0, 9
  call baz(%0)
}
void baz(%10) {
  %11 = getelementptr %0, 0, 9
  %12 = load %11
  call bar(%11)
}
```  
New version of foo after inlining the call to baz:
```llvm
void foo(%0) {
  %1 = getelementptr %0, 0, 9
  %2 = getelementptr %0, 0, 9
  %3 = load %2
  call bar(%3)
}
```    
 In real-world cases, `%1` and `%2` can be in different basic blocks and the redundancy may be hard to detect. The GVN pass removes the redundant GEP instruction.
    
Add test which requires the pass to be run, otherwise ends with a false positive.

The first commit also improves logging for comparisons after function inlining by adding missing comparison header/footer and printing the full inlined functions in VERBOSE_EXTRA mode.

