### PR TITLE
Viewer: react-diff-view empty context line fix

### DIFF
--- a/view/package-lock.json
+++ b/view/package-lock.json
@@ -20,7 +20,7 @@
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-bootstrap": "^2.7.2",
-        "react-diff-view": "^2.4.10",
+        "react-diff-view": "^3.2.1",
         "react-dom": "^18.2.0",
         "react-error-boundary": "^4.0.4",
         "react-scripts": "5.0.1",
@@ -9315,6 +9315,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "node_modules/gitdiff-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gitdiff-parser/-/gitdiff-parser-0.3.1.tgz",
+      "integrity": "sha512-YQJnY8aew65id8okGxKCksH3efDCJ9HzV7M9rsvd65habf39Pkh4cgYJ27AaoDMqo1X98pgNJhNMrm/kpV7UVQ=="
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -15656,18 +15661,19 @@
       }
     },
     "node_modules/react-diff-view": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-2.4.10.tgz",
-      "integrity": "sha512-H9cyh+a002RyP4BMkSaL4OOBDNhkVpaCA+8oHeb6kS3X9Sj8cZymRHf/CyVkTmm+je/qWMa8Po0VBwSnktQ79w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.2.1.tgz",
+      "integrity": "sha512-JoDahgiyeReeH9W9lrI3Z4c4esbd/HNAOdThj6Pce/ZAukFBmXSbZ4Qv8ayo7yow+fTpRNfqtQ9gX5nArEi08w==",
       "dependencies": {
-        "classnames": "^2.2.6",
+        "classnames": "^2.3.2",
         "diff-match-patch": "^1.0.5",
-        "shallow-equal": "^1.2.1",
-        "warning": "^4.0.2"
+        "gitdiff-parser": "^0.3.1",
+        "lodash": "^4.17.21",
+        "shallow-equal": "^3.1.0",
+        "warning": "^4.0.3"
       },
       "peerDependencies": {
-        "prop-types": ">=15.6",
-        "react": ">=16.8"
+        "react": ">=16.14.0"
       }
     },
     "node_modules/react-dom": {
@@ -16568,9 +16574,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -25469,6 +25475,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gitdiff-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/gitdiff-parser/-/gitdiff-parser-0.3.1.tgz",
+      "integrity": "sha512-YQJnY8aew65id8okGxKCksH3efDCJ9HzV7M9rsvd65habf39Pkh4cgYJ27AaoDMqo1X98pgNJhNMrm/kpV7UVQ=="
+    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -29858,14 +29869,16 @@
       }
     },
     "react-diff-view": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-2.4.10.tgz",
-      "integrity": "sha512-H9cyh+a002RyP4BMkSaL4OOBDNhkVpaCA+8oHeb6kS3X9Sj8cZymRHf/CyVkTmm+je/qWMa8Po0VBwSnktQ79w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-diff-view/-/react-diff-view-3.2.1.tgz",
+      "integrity": "sha512-JoDahgiyeReeH9W9lrI3Z4c4esbd/HNAOdThj6Pce/ZAukFBmXSbZ4Qv8ayo7yow+fTpRNfqtQ9gX5nArEi08w==",
       "requires": {
-        "classnames": "^2.2.6",
+        "classnames": "^2.3.2",
         "diff-match-patch": "^1.0.5",
-        "shallow-equal": "^1.2.1",
-        "warning": "^4.0.2"
+        "gitdiff-parser": "^0.3.1",
+        "lodash": "^4.17.21",
+        "shallow-equal": "^3.1.0",
+        "warning": "^4.0.3"
       }
     },
     "react-dom": {
@@ -30528,9 +30541,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+      "integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg=="
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/view/package.json
+++ b/view/package.json
@@ -23,7 +23,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "GENERATE_SOURCEMAP=false react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/view/package.json
+++ b/view/package.json
@@ -15,7 +15,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.7.2",
-    "react-diff-view": "^2.4.10",
+    "react-diff-view": "^3.2.1",
     "react-dom": "^18.2.0",
     "react-error-boundary": "^4.0.4",
     "react-scripts": "5.0.1",

--- a/view/src/tests/DiffViewWrapper.test.jsx
+++ b/view/src/tests/DiffViewWrapper.test.jsx
@@ -49,7 +49,9 @@ function testCodeNumberMatch(
       try {
         // Note: This will also fail if line is shown but we expect no lines
         // to be shown (oldCode is an empty string).
-        expect(lineCode).toBe(oldCodeLines[lineNumber - 1]);
+        // Note 2: Using trimEnd because react-diff-view package from 3.2.0
+        // version renders empty line as line with space.
+        expect(lineCode.trimEnd()).toBe(oldCodeLines[lineNumber - 1]);
       } catch (e) {
         e.message += `\nReceived line number in old file: ${lineNumber}`;
         throw e;
@@ -61,7 +63,7 @@ function testCodeNumberMatch(
       const lineNumber = Number(cells[2].textContent);
       const lineCode = cells[3].textContent;
       try {
-        expect(lineCode).toBe(newCodeLines[lineNumber - 1]);
+        expect(lineCode.trimEnd()).toBe(newCodeLines[lineNumber - 1]);
       } catch (e) {
         e.message += `\nReceived line number in new file: ${lineNumber}`;
         throw e;


### PR DESCRIPTION
The [`react-diff-view`](https://github.com/otakustay/react-diff-view/) package which we are using for rendering code in the viewer contained a bug that was fixed in `3.2.1` version. This PR updates the used version of `react-diff-view` package to the latest version (containing the fix).

If a diff contained an empty context line below the diff, the bug was causing the line was not rendered.  When the rest of the code was expanded the line was still missing and sometimes the last shown line was duplicated.
The bug could be encountered e.g. between `4.18.0-193.el8` and `4.18.0-240.el8` version when viewing code for `schedule_hrtimeout_range_clock` differing function in `schedule_hrtimeout_range` compared function.
The code looked before the update like this:
- Missing context line below diff: ![image](https://github.com/diffkemp/diffkemp/assets/80856731/91b82204-8424-4711-920a-fcba1c003f68)
- Missing line: ![image](https://github.com/diffkemp/diffkemp/assets/80856731/d29a42b2-7748-4e05-8417-e768883ff518)
- Duplicated last lines: ![image](https://github.com/diffkemp/diffkemp/assets/80856731/bbdfd410-1642-4608-ad63-9b2e9f9fc709)

After the update it looks fine:
- Empty context line below diff is shown: ![image](https://github.com/diffkemp/diffkemp/assets/80856731/dc4c4eff-342b-4e68-8af7-2e7c2af9a321)
- No missing line, no duplication of lines: ![image](https://github.com/diffkemp/diffkemp/assets/80856731/47e53932-96b8-47ae-956f-243de494b5db)

Also after the version update, warnings about missing source map was showing when running `bin/diffkemp view --devel` which polluted a lot of the console output, so the second commit was added to hide the warnings.