### PR TITLE
build-kernel: ignore sysctl usages in non-x86 arch

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -346,6 +346,11 @@ def generate_from_sysctl_list(snapshot, sysctl_list):
                 for data_fun in data_mod.get_functions_using_param(data):
                     if data_fun == proc_fun:
                         continue
+                    # For now, we only support the x86 architecture in kernel
+                    if "/arch/" in data_mod.llvm and \
+                            "/arch/x86/" not in data_mod.llvm:
+                        continue
+
                     snapshot.add_fun(
                         name=data_fun,
                         llvm_mod=data_mod,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,7 +83,8 @@ from the Linux kernel. Its main advantage is that it does not build the
 entire kernel, only the files containing functions from `SYMBOL_LIST`. The
 kernel source to build must be properly configured (by `make prepare`) and
 all the tools necessary for building kernel must be installed. It also
-requires the `cscope` tool to be installed.
+requires the `cscope` tool to be installed. At the moment, the command only
+supports the x86 architecture.
 
 #### Comparing sysctl options
 


### PR DESCRIPTION
When searching for usages of a global variable corresponding to a sysctl parameter, there may be multiple functions of the same name (using the sysctl variable) for different arches. In such a case, the snapshot would use the latest one found which may lead to false positives if one snapshot ends up using the implementation from a different architecture than the other.

For building symbol definitions, we always [prefer](https://github.com/diffkemp/diffkemp/blob/master/diffkemp/llvm_ir/kernel_llvm_source_builder.py#L298-L300) definitions for the x86 architecture. This is impossible to do when searching for all functions using a variable, so this disables adding functions from non-x86 architectures to the snapshot.

Also update the documentation to state that we only support x86 in `build-kernel`.