### PR TITLE
Add deps for building upstream kernel to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,8 @@
               diffutils
               gtest
               gnumake
+              libmpc
+              mpfr
             ];
 
             propagatedBuildInputs = with python3Packages; [


### PR DESCRIPTION
In order to build some of the newer kernel versions (e.g. 6.9 that we used for experimenting with refactoring commits), libmpc and mpfr are now required, otherwise make prepare fails.