### PR TITLE
Add deps for building of security libs to nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,8 @@
           mkShell {
             inputsFrom = [ diffkemp-pkg ];
 
+            # Dependies for projects on which we run experiments
+            # (kernel, security libraries, ...).
             buildInputs = [
               bc
               bison
@@ -103,12 +105,18 @@
               rhel_kernel_get
               rpm
               xz
+              libtool
+              autoconf
+              automake
+              autogen
             ];
 
             propagatedBuildInputs = with python3Packages; [
               pytest
               pytest-mock
               flake8
+              jinja2
+              jsonschema
             ];
 
             WITHOUT_RPYTHON = true;


### PR DESCRIPTION
We are doing experiments using DiffKemp with security libraries (MbedTLS, Nettle, Sodium, Wolfssl). Some of these libraries need extra dependencies to be able to make snapshots of them. This PR adds the dependencies to nix development shell.