### PR TITLE
Add llvm.dbg.assign to supported debug intrinsics

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -47,6 +47,9 @@ bool isDebugInfo(const Instruction &Instr) {
 bool isDebugInfo(const Function &Fun) {
     return Fun.getIntrinsicID() == Intrinsic::dbg_declare
            || Fun.getIntrinsicID() == Intrinsic::dbg_value
+#if LLVM_VERSION_MAJOR >= 16
+           || Fun.getIntrinsicID() == Intrinsic::dbg_assign
+#endif
            || Fun.getIntrinsicID() == Intrinsic::dbg_label;
 }
 


### PR DESCRIPTION
Add support of `llvm.dbg.assign` instruction [1] which was introduced in LLVM 16 [2]. Now we are skipping this intrinsics instruction which should solve some false positives.

[1] https://llvm.org/docs/SourceLevelDebugging.html#llvm-dbg-assign
[2] https://www.github.com/llvm/llvm-project/commit/33c7ae55e729069be754f56c4d4606cdeddd377b