### PR TITLE
Add wget to Nix flake devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,7 @@
               openssl
               rhel_kernel_get
               rpm
+              wget
               xz
               libtool
               autoconf


### PR DESCRIPTION
We use wget to download sources of some projects analysed in experiments.