### PR TITLE
Check kernel config before creating snapshot

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -204,6 +204,12 @@ def build_kernel(args):
     """
     # Create a new snapshot from the kernel source directory.
     source_finder = KernelLlvmSourceBuilder(args.source_dir)
+    if not source_finder.is_configured():
+        sys.stderr.write(
+            "Error: Kernel configuration is incomplete or invalid.\n"
+            "Run `make olddefconfig` to set missing configurations.\n"
+        )
+        sys.exit(errno.EINVAL)
     source = KernelSourceTree(args.source_dir, source_finder)
     list_kind = "sysctl" if args.sysctl else "function"
     snapshot = Snapshot.create_from_source(source,


### PR DESCRIPTION
As discribed in issue #313, there can be problem with creating snapshot of kernel if it has missing configuration option. DiffKemp in that case is hanging for input which sets the option. Therefore this commit add check if the kernel is properly configured before creating snapshot
(running `make V=1 --just-print ...` which is used to get command which should be used for compiling of the source file to LLVM IR and which caused the hanging for the config).

The check of kernel config is managed by running `make oldconfig` which prompts for setting of necessary unset options. If we find out the command was prompting for input (contained message 'Restart config' or run too long), we end DiffKemp with apropriate error message.