### PR TITLE
Docs: Fix broken diagram in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ config:
 /* redefinition of subgraphs labels */
 .cluster-label {
   font-family: monospace;
-  font-size: 16px;
+  font-size: 13px;
 }
 "
   themeVariables:
@@ -61,16 +61,16 @@ subgraph G[" "]
     %% nodes
     pv(project versions)
     sl(symbol list)
-    subgraph sgSubgraph[diffkemp build\ndiffkemp build-kernel\ndiffkemp llvm-to-snapshot]
-        sg(Snapshot\ngeneration)
+    subgraph sgSubgraph[diffkemp build<br/>diffkemp build-kernel<br/>diffkemp llvm-to-snapshot]
+        sg(Snapshot<br/>generation)
     end
     subgraph scSubgraph[diffkemp compare]
-        sc(Semantic\ncomparison)
+        sc(Semantic<br/>comparison)
     end
     subgraph rvSubgraph[diffkemp view]
         rv(Result viewer)
     end
-    report[report for\nnot equal symbols]
+    report[report for<br/>not equal symbols]
     neq(✗ not equal)
     eq(✓ equal)
     %% invisible node for making pv node more aligned with other nodes


### PR DESCRIPTION
Github updated to the latest version of Mermaid (v11.1.0), which caused issues with our diagram in `README.md`.
![image](https://github.com/user-attachments/assets/adb9d206-a9dd-43e7-ab68-53889cd0774d)
It looks like Mermaid v11.1.0 no longer supports `\n` for line breaks (probably caused by the introduction of new string syntax [1]). This was fixed by replacing `\n` with `<br/>` tags.

There was also a problem with long labels in the diagram:
- In Firefox, the whole label disappeared [2].
  ![image](https://github.com/user-attachments/assets/0b2c76d0-afb2-4f54-91a4-18063f735b94)
- In Chrome, the label was auto-wrapped, resulting in a poor rendering output.
  ![image](https://github.com/user-attachments/assets/321865ab-b96f-4437-b2ab-ffcbade0b986)

To fix these problems, the font size of cluster labels was reduced.
![image](https://github.com/user-attachments/assets/efc6b7d6-fbd4-4232-9c35-590953184c2a)
Note: The font size is not ideal (too small) but for now I do not have better solution.

[1] https://www.github.com/mermaid-js/mermaid/pull/4271
[2] https://www.github.com/mermaid-js/mermaid/issues/5785