### PR TITLE
CI: Check DiffKemp builds by running their binary

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,8 @@
 name: Builds
 
 on: [push, pull_request]
+env:
+  llvm: 17
 
 jobs:
   nix-build:
@@ -13,6 +15,69 @@ jobs:
         run: nix build
       - name: Run built Diffkemp
         run: result/bin/diffkemp --help
+
+  local-build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - build-type: release
+            diffkemp-bin: diffkemp
+          - build-type: development
+            diffkemp-bin: bin/diffkemp
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install cmake ninja-build libgtest-dev
+          pip install -r requirements.txt
+      - name: Install LLVM
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${{ env.llvm }} main"
+          sudo apt update
+          sudo apt install llvm-${{ env.llvm }}-dev clang-${{ env.llvm }}
+          echo "/usr/lib/llvm-${{ env.llvm }}/bin" >> $GITHUB_PATH
+      - name: Release build and install of DiffKemp
+        if: ${{ matrix.build-type == 'release' }}
+        run: |
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Release
+          sudo ninja -C build install
+          pip install .
+          sudo install -m 0755 bin/diffkemp /usr/bin/diffkemp
+      - name: Development build of DiffKemp
+        if: ${{ matrix.build-type == 'development' }}
+        run: |
+          cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug
+          sudo ninja -C build
+          pip install -e .
+      - name: Check by building and comparing make-based project
+        run: |
+          ${{matrix.diffkemp-bin}} build tests/testing_projects/make_based/ old-snapshot
+          ${{matrix.diffkemp-bin}} build tests/testing_projects/make_based/ new-snapshot
+          ${{matrix.diffkemp-bin}} compare old-snapshot new-snapshot
+
+  nix-development-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v10
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - name: Build DiffKemp
+        run: >
+          nix develop . --command bash -c
+          "cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug &&
+           ninja -C build"
+      - name: Check by building and comparing make-based project
+        run: >
+          nix develop . --command bash -c
+          "setuptoolsShellHook &&
+           bin/diffkemp build tests/testing_projects/make_based/ old-snapshot &&
+           bin/diffkemp build tests/testing_projects/make_based/ new-snapshot &&
+           bin/diffkemp compare old-snapshot new-snapshot"
 
   cc-wrapper-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds to the CI checking that it is possible to use DiffKemp after building it. We have multiple ways how to build DiffKemp:
- nix development build (`nix develop`, `cmake, ninja`, `setuptoolsShellHook`)
- local development build (`cmake`, `ninja`, `pip install -e .`)
- build and installation from sources (`cmake`, `ninja`, `pip install .`, `install ...`).

Each way how to build DiffKemp is done and after that check that the DiffKemp is usable is done by building and comparing `make`-based project (which is already part of the repository and used for unit tests).

The CI should be able to check basic functionality of #344 with some adjustments (removal of `setuptoolsShellHook`, `pip install -e.`, ...).