### PR TITLE
CI: drop magic-nix-cache-action

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build using nix
         run: nix build
       - name: Run built Diffkemp
@@ -65,7 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build DiffKemp
         run: >
           nix develop . --command bash -c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
 
       - name: Delete unused software
         # This is necessary for running CScope database build as it takes


### PR DESCRIPTION
The action will stop working for free GitHub accounts from Feb 1 [0].

[0] https://determinate.systems/posts/magic-nix-cache-free-tier-eol/