### PR TITLE
Various CI fixes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build using nix
         run: nix build
       - name: Run built Diffkemp
@@ -65,7 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build DiffKemp
         run: >
           nix develop . --command bash -c

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -80,7 +80,7 @@ jobs:
            bin/diffkemp compare old-snapshot new-snapshot"
 
   cc-wrapper-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Pip3 backup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
 
       - name: Delete unused software
         # This is necessary for running CScope database build as it takes

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -7,16 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Dependencies
-        working-directory: ${{ github.workspace }}
-        shell: bash
-        run: sudo apt-get install clang-format
+      - uses: DeterminateSystems/nix-installer-action@v10
 
       - name: Check Coding Style
         working-directory: ${{ github.workspace }}
         shell: bash
-        run: tools/check-clang-format.sh -d
+        run: nix develop .#diffkemp-llvm17 --command tools/check-clang-format.sh -d
 
   code-style-python:
     runs-on: ubuntu-latest

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -99,7 +99,7 @@ void freePointerArray(struct ptr_array PtrArr) { delete[] PtrArr.arr; }
 
 void freeStringArray(struct ptr_array PtrArr) {
     for (unsigned long i = 0; i < PtrArr.len; i++)
-        delete[](char *) PtrArr.arr[i];
+        delete[] (char *)PtrArr.arr[i];
 
     freePointerArray(PtrArr);
 }


### PR DESCRIPTION
CI is currently failing due to updates in GitHub runners:
- New clang-format find more styling issues in C++ code. To prevent such failures in future, run clang-format in Nix with a deterministic version (currently 17). Also fix one issue found by clang-format-17.
- Ubuntu 24.04 completely dropped Python 2 so we cannot build the CC-wrapper there anymore. Switch that particular job to Ubuntu 22.04 until we replace RPython by something better.

Also, the `magic-nix-cache-action` is becoming [paid](https://determinate.systems/posts/magic-nix-cache-free-tier-eol/) on Feb 1 so we need to drop it, otherwise our workflows will stop working.