### PR TITLE
Viewer: use relative paths in the build

### DIFF
--- a/view/package.json
+++ b/view/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
+  "homepage": ".",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
When building viewer using `npm run build`, the `index.html` expects js and css files to be located in `/static` [1] that makes it impossible to run static server from different than the `build` directory that contains the `index.html`. This commit fixes it by adding homepage that changes the paths to relative -> `./static/...`.

[1] https://create-react-app.dev/docs/deployment/