### PR TITLE
Use bitcode files instead of textual in snapshots

### DIFF
--- a/diffkemp/building/cc_wrapper.py
+++ b/diffkemp/building/cc_wrapper.py
@@ -135,14 +135,14 @@ def wrapper(argv):
         if index > 1 and argv[index - 1] == "-o":
             if is_object_file and not linking:
                 # Compiling to object file: swap .o with .ll
-                arg = arg.rsplit(".", 1)[0] + ".ll"
+                arg = arg.rsplit(".", 1)[0] + ".bc"
             if not is_object_file and linking:
                 # Linking: add a .llw suffix (LLVM IR whole)
                 arg = arg + ".llw"
             output_file = arg
         elif is_object_file and linking:
             # Input to linking phase: change suffix to .ll
-            arg = arg.rsplit(".", 1)[0] + ".ll"
+            arg = arg.rsplit(".", 1)[0] + ".bc"
             clang = llvm_link
         elif is_source_file and linking:
             # Mark as linking with sources to detect hybrid mode
@@ -153,16 +153,16 @@ def wrapper(argv):
         # Compile/link mode with object files detected
         # Drop object files and revert to normal compile/link mode
         clang = old_clang
-        clang_argv = [arg for arg in clang_argv if not arg.endswith(".ll")]
+        clang_argv = [arg for arg in clang_argv if not arg.endswith(".bc")]
 
     # Do not continue if output is not .ll or .llw
     # Note: this means that this is neither compilation nor linking
-    if (output_file is not None and not output_file.endswith(".ll") and
+    if (output_file is not None and not output_file.endswith(".bc") and
             not output_file.endswith(".llw")):
         return 0
 
     # Do not run clang on conftest files
-    if output_file in ["conftest.ll", "conftest.llw"] or "conftest.c" in argv:
+    if output_file in ["conftest.bc", "conftest.llw"] or "conftest.c" in argv:
         return 0
 
     # Not compiling C source file
@@ -176,7 +176,7 @@ def wrapper(argv):
     elif not linking:
         # Compiling to default output file
         db.extend(["o:" + os.path.join(os.getcwd(),
-                                       arg.rsplit(".", 1)[0] + ".ll")
+                                       arg.rsplit(".", 1)[0] + ".bc")
                    for arg in clang_argv if not arg.endswith(".c")])
 
     # Analyze and modify parameters for clang (phase 2)
@@ -192,7 +192,7 @@ def wrapper(argv):
     else:
         # Keep only arguments with input files (and llvm-link itself)
         clang_argv = [arg for arg in clang_argv if arg == clang or
-                      arg.endswith(".ll") or arg.endswith(".llw") or
+                      arg.endswith(".bc") or arg.endswith(".llw") or
                       arg == "-o"]
         # Remove non-existent files
         # Note: these might have been e.g. generated from assembly

--- a/diffkemp/llvm_ir/compiler.py
+++ b/diffkemp/llvm_ir/compiler.py
@@ -8,7 +8,7 @@ This file must be RPython compatible because it is used from cc_wrapper.
 def get_clang_default_options(default_optim=True):
     """Returns clang options for compiling c files to LLVM IR.
     :param default_optim: By default adds also optimization flags."""
-    opts = ["-S", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"]
+    opts = ["-c", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"]
     if default_optim:
         opts.extend(["-O1", "-Xclang", "-disable-llvm-passes"])
     return opts

--- a/diffkemp/llvm_ir/kernel_llvm_source_builder.py
+++ b/diffkemp/llvm_ir/kernel_llvm_source_builder.py
@@ -70,7 +70,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
                 llvm_filename = self._build_source_to_llvm(source_path)
                 if os.path.isfile(llvm_filename):
                     mod = LlvmModule(llvm_filename)
-                    if mod.has_function(symbol) or mod.has_global(symbol):
+                    if mod.has_definition(symbol):
                         break
             except BuildException:
                 pass
@@ -397,7 +397,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
 
             # Output name is given by replacing .c by .ll in source name
             if param.endswith(".c"):
-                output_file = "{}.ll".format(param[:-2])
+                output_file = "{}.bc".format(param[:-2])
 
             command.append(KernelLlvmSourceBuilder._strip_bash_quotes(param))
         if output_file is None:
@@ -414,10 +414,10 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
         :param ld_command: Command to convert
         :return Corresponding llvm-link command.
         """
-        command = ["llvm-link", "-S"]
+        command = ["llvm-link"]
         for param in ld_command.split():
             if param.endswith(".o"):
-                command.append("{}.ll".format(param[:-2]))
+                command.append("{}.bc".format(param[:-2]))
             elif param == "-o":
                 command.append(param)
         return command
@@ -487,7 +487,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
     @staticmethod
     def _get_build_source(command):
         """Get name of the object file built by the command."""
-        return command[command.index("-c") + 1]
+        return command[-1]
 
     def _kbuild_object_command(self, object_file):
         """
@@ -568,7 +568,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
         :param source_file: C source to build
         :return: Created LLVM IR file
         """
-        llvm_file = "{}.ll".format(source_file[:-2])
+        llvm_file = "{}.bc".format(source_file[:-2])
         if (not os.path.isfile(llvm_file) or os.path.getmtime(llvm_file) <
                 os.path.getmtime(source_file)):
             cwd = os.getcwd()
@@ -627,7 +627,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
                         obj = self._get_build_object(c)
                         if not os.path.isfile(obj) or built:
                             check_call(c, stderr=stderr)
-            llvm_file = os.path.join(mod_dir, "{}.ll".format(file_name))
+            llvm_file = os.path.join(mod_dir, "{}.bc".format(file_name))
             opt_llvm(llvm_file)
             return llvm_file
         except CalledProcessError:

--- a/diffkemp/llvm_ir/single_c_builder.py
+++ b/diffkemp/llvm_ir/single_c_builder.py
@@ -22,7 +22,7 @@ class SingleCBuilder(SingleLlvmFinder):
         :param default_optim: use default optimalisations flags
             and run LLVM IR simplification passes
         """
-        llvm_file_name = os.path.splitext(c_file_name)[0] + ".ll"
+        llvm_file_name = os.path.splitext(c_file_name)[0] + ".bc"
         SingleLlvmFinder.__init__(self, source_dir, llvm_file_name)
 
         self.c_file_name = c_file_name

--- a/tests/regression/mock_source_tree.py
+++ b/tests/regression/mock_source_tree.py
@@ -22,7 +22,7 @@ class MockSourceTree(SourceTree):
         self.real_source_tree = real_source_tree
 
     def get_module_for_symbol(self, symbol, created_before=None):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(symbol))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(symbol))
         src_file = os.path.join(self.source_dir, "{}.c".format(symbol))
 
         if not os.path.exists(llvm_file) and self.real_source_tree is not None:
@@ -35,7 +35,7 @@ class MockSourceTree(SourceTree):
         return LlvmModule(llvm_file, src_file)
 
     def get_kernel_module(self, mod_dir, mod_name):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(mod_name))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(mod_name))
 
         if not os.path.exists(llvm_file):
             assert self.real_source_tree is not None
@@ -45,7 +45,7 @@ class MockSourceTree(SourceTree):
         return LlvmModule(llvm_file)
 
     def get_sysctl_module(self, sysctl):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(sysctl))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(sysctl))
         table_file = os.path.join(self.source_dir, "table")
 
         if not os.path.exists(llvm_file):

--- a/tests/testing_projects/make_based/Makefile
+++ b/tests/testing_projects/make_based/Makefile
@@ -23,4 +23,4 @@ file.so: file.o
 	$(CC) $(CFLAGS) -o $@ $^ -shared
 
 clean:
-	rm -f *.o *.ll *.so
+	rm -f *.o *.ll *.so *.bc

--- a/tests/unit_tests/kernel_llvm_source_builder_test.py
+++ b/tests/unit_tests/kernel_llvm_source_builder_test.py
@@ -38,13 +38,13 @@ def test_find_llvm_with_symbol_def(builder):
     Test building LLVM module from a source containing a function definition.
     """
     llvm_file = builder.find_llvm_with_symbol_def("__alloc_workqueue_key")
-    assert llvm_file == os.path.join(builder.source_dir, "kernel/workqueue.ll")
+    assert llvm_file == os.path.join(builder.source_dir, "kernel/workqueue.bc")
 
 
 def test_find_llvm_with_symbol_use(builder):
     """Test finding sources using a global variable."""
     srcs = builder.find_llvm_with_symbol_use("net_ratelimit_state")
-    assert srcs == {os.path.join(builder.source_dir, "net/core/utils.ll")}
+    assert srcs == {os.path.join(builder.source_dir, "net/core/utils.bc")}
 
 
 def test_build_cscope_database(builder):
@@ -97,7 +97,7 @@ def test_kbuild_module_commands(builder):
 def test_build_src_to_llvm(builder):
     """Building single object into LLVM."""
     llvm_file = builder._build_source_to_llvm("sound/core/init.c")
-    assert (llvm_file == "sound/core/init.ll")
+    assert (llvm_file == "sound/core/init.bc")
     assert os.path.isfile(os.path.join(builder.source_dir, llvm_file))
 
 
@@ -110,7 +110,7 @@ def test_build_src_to_llvm_fail(builder):
 def test_build_mod_to_llvm(builder):
     """Test building kernel module into LLVM"""
     mod_file = os.path.join(builder.source_dir,
-                            "drivers/firewire/firewire-sbp2.ll")
+                            "drivers/firewire/firewire-sbp2.bc")
     if os.path.isfile(mod_file):
         os.unlink(mod_file)
     builder._build_kernel_mod_to_llvm("drivers/firewire", "firewire-sbp2")

--- a/tests/unit_tests/kernel_module_test.py
+++ b/tests/unit_tests/kernel_module_test.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import shutil
 import tempfile
+from subprocess import Popen, PIPE
 
 
 @pytest.fixture
@@ -84,14 +85,16 @@ def test_move_to_other_root_dir(source):
     # Check that source (C and LLVM) files have been moved.
     mod.move_to_other_root_dir(os.path.abspath("kernel/linux-3.10.0-957.el7"),
                                tmp)
-    assert os.path.isfile(os.path.join(tmp, "sound/core/init.ll"))
+    assert os.path.isfile(os.path.join(tmp, "sound/core/init.bc"))
 
     # Check that the llvm file does not contain the original directory.
-    assert mod.llvm == os.path.join(tmp, "sound/core/init.ll")
-    with open(mod.llvm, "r") as llvm:
-        for line in llvm.readlines():
-            assert ("constant" in line or
-                    "kernel/linux-3.10.0-957.el7" not in line)
+    assert mod.llvm == os.path.join(tmp, "sound/core/init.bc")
+    cat_out = Popen(["cat", mod.llvm], stdout=PIPE, text=True)
+    dis_out = Popen(["llvm-dis"], stdin=cat_out.stdout, stdout=PIPE, text=True)
+    output, error = dis_out.communicate()
+    for line in output.splitlines():
+        assert ("constant" in line or
+                "kernel/linux-3.10.0-957.el7" not in line)
 
     shutil.rmtree(tmp)
 

--- a/tests/unit_tests/kernel_source_tree_test.py
+++ b/tests/unit_tests/kernel_source_tree_test.py
@@ -18,10 +18,10 @@ def source():
 
 @pytest.mark.parametrize("name, llvm_file, table", [
     ("net.core.message_burst",
-     "net/core/sysctl_net_core.ll",
+     "net/core/sysctl_net_core.bc",
      "net_core_table"),
     ("kernel.usermodehelper.bset",
-     "kernel/kmod.ll",
+     "kernel/kmod.bc",
      "usermodehelper_table")
 ])
 def test_get_sysctl_module(source, name, llvm_file, table):

--- a/tests/unit_tests/source_tree_test.py
+++ b/tests/unit_tests/source_tree_test.py
@@ -30,7 +30,7 @@ def test_get_module_for_symbol(source):
     """
     mod = source.get_module_for_symbol("__alloc_workqueue_key")
     assert mod is not None
-    assert mod.llvm == os.path.join(source.source_dir, "kernel/workqueue.ll")
+    assert mod.llvm == os.path.join(source.source_dir, "kernel/workqueue.bc")
     assert mod.has_function("__alloc_workqueue_key")
 
 
@@ -41,7 +41,7 @@ def test_get_module_for_symbol_built_after(source):
     The LLVM file should not be retrieved.
     """
     before_time = datetime.datetime.now() - datetime.timedelta(minutes=1)
-    llvm_file = os.path.join(source.source_dir, "kernel/workqueue.ll")
+    llvm_file = os.path.join(source.source_dir, "kernel/workqueue.bc")
 
     # Temporarily change mtime of the LLVM IR file to now
     stat = os.stat(llvm_file)
@@ -60,7 +60,7 @@ def test_get_module_for_symbol_built_after(source):
 def test_get_module_for_symbol_fail(source):
     """Test getting LLVM module for a non-existing function definition."""
     with pytest.raises(SourceNotFoundException):
-        source.get_module_for_symbol("__get_user_2")
+        source.get_module_for_symbol("__get_user_3")
 
 
 def test_get_modules_using_symbol(source):
@@ -71,8 +71,8 @@ def test_get_modules_using_symbol(source):
     assert len(mods) == 2
     assert set([m.llvm for m in mods]) == \
         set([os.path.join(source.source_dir, f)
-             for f in ["net/core/sock.ll",
-                       "net/netfilter/ipvs/ip_vs_sync.ll"]])
+             for f in ["net/core/sock.bc",
+                       "net/netfilter/ipvs/ip_vs_sync.bc"]])
 
 
 def test_copy_source_files(source):
@@ -87,8 +87,8 @@ def test_copy_source_files(source):
         assert os.path.isdir(os.path.join(tmp_source.source_dir, d))
 
     # Check that files were successfully copied.
-    for f in ["net/core/utils.c", "net/core/utils.ll", "kernel/workqueue.c",
-              "kernel/workqueue.ll", "include/linux/module.h",
+    for f in ["net/core/utils.c", "net/core/utils.bc", "kernel/workqueue.c",
+              "kernel/workqueue.bc", "include/linux/module.h",
               "include/linux/kernel.h"]:
         assert os.path.isfile(os.path.join(tmp_source.source_dir, f))
 


### PR DESCRIPTION
Changes in the Python code enabling the use of LLVM IR bitcode files. This version:
- uses LLVM command line utilities and modified regular expressions,
- introduces `has_definition`, 
- fixes an ambiguous unit test (`test_get_module_for_symbol_fail`),
- adapts the tests to bitcode files.

As a result, the snapshot size is reduced without a significant increase in the runtime.
Resolves #352.