### PR TITLE
Compare function refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ cmake-build-debug/
 # Vim files
 *.swp
 
+# Vs Code files
+.vscode/
+
 # Temporary files from regression tests. Used for debugging purposes only.
 *.ll
 *.smt2

--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -1,6 +1,7 @@
 import argparse
 from argparse import ArgumentParser, ArgumentTypeError, SUPPRESS
 from diffkemp.building.build_kernel import build_kernel
+from diffkemp.compare import compare
 import diffkemp.diffkemp
 import os
 
@@ -200,7 +201,7 @@ def make_argument_parser():
                             dest="disable_pattern", const="all",
                             help="disable all built-in patterns")
 
-    compare_ap.set_defaults(func=diffkemp.diffkemp.compare)
+    compare_ap.set_defaults(func=compare)
 
     # "view" sub-command
     view_ap = sub_ap.add_parser("view",

--- a/diffkemp/compare.py
+++ b/diffkemp/compare.py
@@ -1,0 +1,204 @@
+from diffkemp.diffkemp import print_syntax_diff
+from diffkemp.config import Config
+from diffkemp.utils import CMP_OUTPUT_FILE
+from diffkemp.llvm_ir.llvm_module import LlvmParam, LlvmModule
+from diffkemp.semdiff.caching import SimpLLCache
+from diffkemp.semdiff.function_diff import functions_diff
+from diffkemp.semdiff.result import Result
+from diffkemp.output import YamlOutput
+from tempfile import mkdtemp
+from timeit import default_timer
+import errno
+import os
+import re
+import sys
+
+
+def compare(args):
+    """
+    Compare the generated snapshots. Runs the semantic comparison and shows
+    information about the compared functions that are semantically different.
+    """
+    # Set the output directory
+    if not args.stdout:
+        if args.output_dir:
+            output_dir = args.output_dir
+            if os.path.isdir(output_dir):
+                sys.stderr.write("Error: output directory exists\n")
+                sys.exit(errno.EEXIST)
+        else:
+            output_dir = default_output_dir(args.snapshot_dir_old,
+                                            args.snapshot_dir_new)
+    else:
+        output_dir = None
+
+    config = Config.from_args(args)
+    result = Result(Result.Kind.NONE, args.snapshot_dir_old,
+                    args.snapshot_dir_old, start_time=default_timer())
+
+    for group_name, group in sorted(config.snapshot_first.fun_groups.items()):
+        group_printed = False
+
+        # Set the group directory
+        if output_dir is not None and group_name is not None:
+            group_dir = os.path.join(output_dir, group_name)
+        else:
+            group_dir = None
+
+        result_graph = None
+        cache = SimpLLCache(mkdtemp())
+        module_cache = {}
+
+        if args.enable_module_cache:
+            modules_to_cache = _get_modules_to_cache(group.functions.items(),
+                                                     group_name,
+                                                     config.snapshot_second,
+                                                     2)
+        else:
+            modules_to_cache = set()
+
+        for fun, old_fun_desc in sorted(group.functions.items()):
+            # Check if the function exists in the other snapshot
+            new_fun_desc = config.snapshot_second.get_by_name(fun, group_name)
+            if not new_fun_desc:
+                continue
+
+            # Check if the module exists in both snapshots
+            if old_fun_desc.mod is None or new_fun_desc.mod is None:
+                result.add_inner(Result(Result.Kind.UNKNOWN, fun, fun))
+                if group_name is not None and not group_printed:
+                    print("{}:".format(group_name))
+                    group_printed = True
+                print("{}: unknown".format(fun))
+                continue
+
+            # If function has a global variable, set it
+            glob_var = LlvmParam(old_fun_desc.glob_var) \
+                if old_fun_desc.glob_var else None
+
+            # Run the semantic diff
+            fun_result = functions_diff(
+                mod_first=old_fun_desc.mod, mod_second=new_fun_desc.mod,
+                fun_first=fun, fun_second=fun,
+                glob_var=glob_var, config=config,
+                prev_result_graph=result_graph, function_cache=cache,
+                module_cache=module_cache, modules_to_cache=modules_to_cache)
+            result_graph = fun_result.graph
+
+            if fun_result is not None:
+                if args.regex_filter is not None:
+                    # Filter results by regex
+                    pattern = re.compile(args.regex_filter)
+                    for called_res in fun_result.inner.values():
+                        if pattern.search(called_res.diff):
+                            break
+                    else:
+                        fun_result.kind = Result.Kind.EQUAL
+
+                result.add_inner(fun_result)
+
+                # Printing information about failures and non-equal functions.
+                if fun_result.kind in [Result.Kind.NOT_EQUAL,
+                                       Result.Kind.UNKNOWN,
+                                       Result.Kind.ERROR] or config.full_diff:
+                    if fun_result.kind == Result.Kind.NOT_EQUAL or \
+                       config.full_diff:
+                        # Create the output directory if needed
+                        if output_dir is not None:
+                            if not os.path.isdir(output_dir):
+                                os.mkdir(output_dir)
+                        # Create the group directory or print the group name
+                        # if needed
+                        if group_dir is not None:
+                            if not os.path.isdir(group_dir):
+                                os.mkdir(group_dir)
+                        elif group_name is not None and not group_printed:
+                            print("{}:".format(group_name))
+                            group_printed = True
+                        print_syntax_diff(
+                            snapshot_dir_old=args.snapshot_dir_old,
+                            snapshot_dir_new=args.snapshot_dir_new,
+                            fun=fun,
+                            fun_result=fun_result,
+                            fun_tag=old_fun_desc.tag,
+                            output_dir=group_dir if group_dir else output_dir,
+                            show_diff=config.show_diff,
+                            full_diff=config.full_diff,
+                            initial_indent=2 if (group_name is not None and
+                                                 group_dir is None) else 0)
+                    else:
+                        # Print the group name if needed
+                        if group_name is not None and not group_printed:
+                            print("{}:".format(group_name))
+                            group_printed = True
+                        print("{}: {}".format(fun, str(fun_result.kind)))
+
+            # Clean LLVM modules (allow GC to collect the occupied memory)
+            old_fun_desc.mod.clean_module()
+            new_fun_desc.mod.clean_module()
+            LlvmModule.clean_all()
+    # Create yaml output
+    if output_dir is not None and os.path.isdir(output_dir):
+        old_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_old), "")
+        new_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_new), "")
+        yaml_output = YamlOutput(snapshot_dir_old=old_dir_abs,
+                                 snapshot_dir_new=new_dir_abs, result=result)
+        yaml_output.save(output_dir=output_dir, file_name=CMP_OUTPUT_FILE)
+    config.snapshot_first.finalize()
+    config.snapshot_second.finalize()
+
+    if output_dir is not None and os.path.isdir(output_dir):
+        print("Differences stored in {}/".format(output_dir))
+
+    if args.report_stat or args.extended_stat:
+        print("")
+        print("Statistics")
+        print("----------")
+        result.stop_time = default_timer()
+        result.report_stat(args.show_errors, args.extended_stat)
+    return 0
+
+
+def default_output_dir(src_snapshot, dest_snapshot):
+    """Name of the directory to put log files into."""
+    base_dirname = "diff-{}-{}".format(
+        os.path.basename(os.path.normpath(src_snapshot)),
+        os.path.basename(os.path.normpath(dest_snapshot)))
+    if os.path.isdir(base_dirname):
+        suffix = 0
+        dirname = base_dirname
+        while os.path.isdir(dirname):
+            dirname = "{}-{}".format(base_dirname, suffix)
+            suffix += 1
+        return dirname
+    return base_dirname
+
+
+def _get_modules_to_cache(functions, group_name, other_snapshot,
+                          min_frequency):
+    """
+    Generates a list of frequently used modules. These will be loaded into
+    cache if DiffKemp is running with module caching enable.
+    :param functions: List of pairs of functions to be compared along
+    with their description objects
+    :param group_name: Name of the group the functions are in
+    :param other_snapshot: Snapshot object for looking up the functions
+    in the other snapshot
+    :param min_frequency: Minimal frequency for a module to be included into
+    the cache
+    :return: Set of modules that should be loaded into module cache
+    """
+    module_frequency_map = dict()
+    for fun, old_fun_desc in functions:
+        # Check if the function exists in the other snapshot
+        new_fun_desc = other_snapshot.get_by_name(fun, group_name)
+        if not new_fun_desc:
+            continue
+        for fun_desc in [old_fun_desc, new_fun_desc]:
+            if not fun_desc.mod:
+                continue
+            if fun_desc.mod.llvm not in module_frequency_map:
+                module_frequency_map[fun_desc.mod.llvm] = 0
+            module_frequency_map[fun_desc.mod.llvm] += 1
+    return {mod for mod, frequency in module_frequency_map.items()
+            if frequency >= min_frequency}

--- a/diffkemp/compare.py
+++ b/diffkemp/compare.py
@@ -14,23 +14,21 @@ import re
 import sys
 
 
+class OutputDirExistsError(Exception):
+    pass
+
+
 def compare(args):
     """
     Compare the generated snapshots. Runs the semantic comparison and shows
     information about the compared functions that are semantically different.
     """
     # Set the output directory
-    if not args.stdout:
-        if args.output_dir:
-            output_dir = args.output_dir
-            if os.path.isdir(output_dir):
-                sys.stderr.write("Error: output directory exists\n")
-                sys.exit(errno.EEXIST)
-        else:
-            output_dir = default_output_dir(args.snapshot_dir_old,
-                                            args.snapshot_dir_new)
-    else:
-        output_dir = None
+    try:
+        output_dir = _set_output_dir(args)
+    except OutputDirExistsError as e:
+        sys.stderr.write("{}".format(e))
+        sys.exit(errno.EEXIST)
 
     config = Config.from_args(args)
     result = Result(Result.Kind.NONE, args.snapshot_dir_old,
@@ -58,6 +56,7 @@ def compare(args):
             modules_to_cache = set()
 
         for fun, old_fun_desc in sorted(group.functions.items()):
+
             # Check if the function exists in the other snapshot
             new_fun_desc = config.snapshot_second.get_by_name(fun, group_name)
             if not new_fun_desc:
@@ -65,11 +64,13 @@ def compare(args):
 
             # Check if the module exists in both snapshots
             if old_fun_desc.mod is None or new_fun_desc.mod is None:
-                result.add_inner(Result(Result.Kind.UNKNOWN, fun, fun))
-                if group_name is not None and not group_printed:
-                    print("{}:".format(group_name))
-                    group_printed = True
-                print("{}: unknown".format(fun))
+                fun_result = Result(Result.Kind.UNKNOWN, fun, fun)
+                result.add_inner(fun_result)
+                group_printed = _print_fun_result(fun_result, config,
+                                                  output_dir, fun,
+                                                  group_dir, group_name,
+                                                  args, old_fun_desc,
+                                                  group_printed)
                 continue
 
             # If function has a global variable, set it
@@ -88,12 +89,7 @@ def compare(args):
             if fun_result is not None:
                 if args.regex_filter is not None:
                     # Filter results by regex
-                    pattern = re.compile(args.regex_filter)
-                    for called_res in fun_result.inner.values():
-                        if pattern.search(called_res.diff):
-                            break
-                    else:
-                        fun_result.kind = Result.Kind.EQUAL
+                    _filter_result_by_regex(args.regex_filter, fun_result)
 
                 result.add_inner(fun_result)
 
@@ -101,65 +97,44 @@ def compare(args):
                 if fun_result.kind in [Result.Kind.NOT_EQUAL,
                                        Result.Kind.UNKNOWN,
                                        Result.Kind.ERROR] or config.full_diff:
-                    if fun_result.kind == Result.Kind.NOT_EQUAL or \
-                       config.full_diff:
-                        # Create the output directory if needed
-                        if output_dir is not None:
-                            if not os.path.isdir(output_dir):
-                                os.mkdir(output_dir)
-                        # Create the group directory or print the group name
-                        # if needed
-                        if group_dir is not None:
-                            if not os.path.isdir(group_dir):
-                                os.mkdir(group_dir)
-                        elif group_name is not None and not group_printed:
-                            print("{}:".format(group_name))
-                            group_printed = True
-                        print_syntax_diff(
-                            snapshot_dir_old=args.snapshot_dir_old,
-                            snapshot_dir_new=args.snapshot_dir_new,
-                            fun=fun,
-                            fun_result=fun_result,
-                            fun_tag=old_fun_desc.tag,
-                            output_dir=group_dir if group_dir else output_dir,
-                            show_diff=config.show_diff,
-                            full_diff=config.full_diff,
-                            initial_indent=2 if (group_name is not None and
-                                                 group_dir is None) else 0)
-                    else:
-                        # Print the group name if needed
-                        if group_name is not None and not group_printed:
-                            print("{}:".format(group_name))
-                            group_printed = True
-                        print("{}: {}".format(fun, str(fun_result.kind)))
-
+                    group_printed = _print_fun_result(fun_result, config,
+                                                      output_dir, fun,
+                                                      group_dir, group_name,
+                                                      args, old_fun_desc,
+                                                      group_printed)
             # Clean LLVM modules (allow GC to collect the occupied memory)
             old_fun_desc.mod.clean_module()
             new_fun_desc.mod.clean_module()
             LlvmModule.clean_all()
+
     # Create yaml output
     if output_dir is not None and os.path.isdir(output_dir):
-        old_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_old), "")
-        new_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_new), "")
-        yaml_output = YamlOutput(snapshot_dir_old=old_dir_abs,
-                                 snapshot_dir_new=new_dir_abs, result=result)
-        yaml_output.save(output_dir=output_dir, file_name=CMP_OUTPUT_FILE)
+        _create_yaml_output(args, result, output_dir)
     config.snapshot_first.finalize()
     config.snapshot_second.finalize()
 
     if output_dir is not None and os.path.isdir(output_dir):
         print("Differences stored in {}/".format(output_dir))
-
     if args.report_stat or args.extended_stat:
-        print("")
-        print("Statistics")
-        print("----------")
-        result.stop_time = default_timer()
-        result.report_stat(args.show_errors, args.extended_stat)
+        _print_stats(args.show_errors, result, args.extended_stat)
     return 0
 
 
-def default_output_dir(src_snapshot, dest_snapshot):
+def _set_output_dir(compare_args):
+    if compare_args.stdout:
+        return None
+
+    if not compare_args.output_dir:
+        return _default_output_dir(compare_args.snapshot_dir_old,
+                                   compare_args.snapshot_dir_new)
+    output_dir = compare_args.output_dir
+    if os.path.isdir(output_dir):
+        raise OutputDirExistsError(
+            "Error: output directory {} exists\n".format(output_dir))
+    return output_dir
+
+
+def _default_output_dir(src_snapshot, dest_snapshot):
     """Name of the directory to put log files into."""
     base_dirname = "diff-{}-{}".format(
         os.path.basename(os.path.normpath(src_snapshot)),
@@ -202,3 +177,67 @@ def _get_modules_to_cache(functions, group_name, other_snapshot,
             module_frequency_map[fun_desc.mod.llvm] += 1
     return {mod for mod, frequency in module_frequency_map.items()
             if frequency >= min_frequency}
+
+
+def _filter_result_by_regex(regex_filter, fun_result):
+    pattern = re.compile(regex_filter)
+    for called_res in fun_result.inner.values():
+        if pattern.search(called_res.diff):
+            return
+    fun_result.kind = Result.Kind.EQUAL
+
+
+def _print_fun_result(fun_result, config, output_dir, fun, group_dir,
+                      group_name, compare_args, old_fun_desc, group_printed):
+    if fun_result.kind != Result.Kind.NOT_EQUAL and \
+       not config.full_diff:
+        # Print the group name if needed
+        if group_name is not None and not group_printed:
+            print("{}:".format(group_name))
+            group_printed = True
+        print("{}: {}".format(fun, str(fun_result.kind)))
+        return group_printed
+
+    # Create the output directory if needed
+    if output_dir is not None:
+        if not os.path.isdir(output_dir):
+            os.mkdir(output_dir)
+
+    # Create the group directory or print the group name
+    # if needed
+    if group_dir is not None:
+        if not os.path.isdir(group_dir):
+            os.mkdir(group_dir)
+    elif group_name is not None and not group_printed:
+        print("{}:".format(group_name))
+        group_printed = True
+
+    print_syntax_diff(
+        snapshot_dir_old=compare_args.snapshot_dir_old,
+        snapshot_dir_new=compare_args.snapshot_dir_new,
+        fun=fun,
+        fun_result=fun_result,
+        fun_tag=old_fun_desc.tag,
+        output_dir=group_dir if group_dir else output_dir,
+        show_diff=config.show_diff,
+        full_diff=config.full_diff,
+        initial_indent=2 if (group_name is not None and
+                             group_dir is None) else 0)
+
+    return group_printed
+
+
+def _create_yaml_output(compare_args, result, output_dir):
+    old_dir_abs = \
+        os.path.join(os.path.abspath(compare_args.snapshot_dir_old), "")
+    new_dir_abs = \
+        os.path.join(os.path.abspath(compare_args.snapshot_dir_new), "")
+    yaml_output = YamlOutput(snapshot_dir_old=old_dir_abs,
+                             snapshot_dir_new=new_dir_abs, result=result)
+    yaml_output.save(output_dir=output_dir, file_name=CMP_OUTPUT_FILE)
+
+
+def _print_stats(errors, result, extended_stat):
+    print(f"\nStatistics\n{'-' * 11}")
+    result.stop_time = default_timer()
+    result.report_stat(errors, extended_stat)

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -4,29 +4,20 @@ from diffkemp.building.build_utils import (
     generate_from_function_list,
     read_symbol_list,
     EMSG_EMPTY_SYMBOL_LIST)
-from diffkemp.config import Config
+from diffkemp.utils import CMP_OUTPUT_FILE
 from diffkemp.snapshot import Snapshot
 from diffkemp.llvm_ir.source_tree import SourceTree
-from diffkemp.llvm_ir.llvm_module import LlvmParam, LlvmModule
 from diffkemp.llvm_ir.single_llvm_finder import SingleLlvmFinder
-from diffkemp.semdiff.caching import SimpLLCache
-from diffkemp.semdiff.function_diff import functions_diff
 from diffkemp.semdiff.result import Result
-from diffkemp.output import YamlOutput
 from diffkemp.syndiff.function_syntax_diff import unified_syntax_diff
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from tempfile import mkdtemp
-from timeit import default_timer
 import errno
 import os
-import re
 import sys
 import shutil
 import yaml
 
 VIEW_INSTALL_DIR = "/var/lib/diffkemp/view"
-# Name of YAML output file created by diffkemp compare command.
-YAML_FILE_NAME = "diffkemp-out.yaml"
 
 
 def build(args):
@@ -60,196 +51,6 @@ def llvm_to_snapshot(args):
     generate_from_function_list(snapshot, function_list)
     snapshot.generate_snapshot_dir()
     snapshot.finalize()
-
-
-def _get_modules_to_cache(functions, group_name, other_snapshot,
-                          min_frequency):
-    """
-    Generates a list of frequently used modules. These will be loaded into
-    cache if DiffKemp is running with module caching enable.
-    :param functions: List of pairs of functions to be compared along
-    with their description objects
-    :param group_name: Name of the group the functions are in
-    :param other_snapshot: Snapshot object for looking up the functions
-    in the other snapshot
-    :param min_frequency: Minimal frequency for a module to be included into
-    the cache
-    :return: Set of modules that should be loaded into module cache
-    """
-    module_frequency_map = dict()
-    for fun, old_fun_desc in functions:
-        # Check if the function exists in the other snapshot
-        new_fun_desc = other_snapshot.get_by_name(fun, group_name)
-        if not new_fun_desc:
-            continue
-        for fun_desc in [old_fun_desc, new_fun_desc]:
-            if not fun_desc.mod:
-                continue
-            if fun_desc.mod.llvm not in module_frequency_map:
-                module_frequency_map[fun_desc.mod.llvm] = 0
-            module_frequency_map[fun_desc.mod.llvm] += 1
-    return {mod for mod, frequency in module_frequency_map.items()
-            if frequency >= min_frequency}
-
-
-def compare(args):
-    """
-    Compare the generated snapshots. Runs the semantic comparison and shows
-    information about the compared functions that are semantically different.
-    """
-    # Set the output directory
-    if not args.stdout:
-        if args.output_dir:
-            output_dir = args.output_dir
-            if os.path.isdir(output_dir):
-                sys.stderr.write("Error: output directory exists\n")
-                sys.exit(errno.EEXIST)
-        else:
-            output_dir = default_output_dir(args.snapshot_dir_old,
-                                            args.snapshot_dir_new)
-    else:
-        output_dir = None
-
-    config = Config.from_args(args)
-    result = Result(Result.Kind.NONE, args.snapshot_dir_old,
-                    args.snapshot_dir_old, start_time=default_timer())
-
-    for group_name, group in sorted(config.snapshot_first.fun_groups.items()):
-        group_printed = False
-
-        # Set the group directory
-        if output_dir is not None and group_name is not None:
-            group_dir = os.path.join(output_dir, group_name)
-        else:
-            group_dir = None
-
-        result_graph = None
-        cache = SimpLLCache(mkdtemp())
-        module_cache = {}
-
-        if args.enable_module_cache:
-            modules_to_cache = _get_modules_to_cache(group.functions.items(),
-                                                     group_name,
-                                                     config.snapshot_second,
-                                                     2)
-        else:
-            modules_to_cache = set()
-
-        for fun, old_fun_desc in sorted(group.functions.items()):
-            # Check if the function exists in the other snapshot
-            new_fun_desc = config.snapshot_second.get_by_name(fun, group_name)
-            if not new_fun_desc:
-                continue
-
-            # Check if the module exists in both snapshots
-            if old_fun_desc.mod is None or new_fun_desc.mod is None:
-                result.add_inner(Result(Result.Kind.UNKNOWN, fun, fun))
-                if group_name is not None and not group_printed:
-                    print("{}:".format(group_name))
-                    group_printed = True
-                print("{}: unknown".format(fun))
-                continue
-
-            # If function has a global variable, set it
-            glob_var = LlvmParam(old_fun_desc.glob_var) \
-                if old_fun_desc.glob_var else None
-
-            # Run the semantic diff
-            fun_result = functions_diff(
-                mod_first=old_fun_desc.mod, mod_second=new_fun_desc.mod,
-                fun_first=fun, fun_second=fun,
-                glob_var=glob_var, config=config,
-                prev_result_graph=result_graph, function_cache=cache,
-                module_cache=module_cache, modules_to_cache=modules_to_cache)
-            result_graph = fun_result.graph
-
-            if fun_result is not None:
-                if args.regex_filter is not None:
-                    # Filter results by regex
-                    pattern = re.compile(args.regex_filter)
-                    for called_res in fun_result.inner.values():
-                        if pattern.search(called_res.diff):
-                            break
-                    else:
-                        fun_result.kind = Result.Kind.EQUAL
-
-                result.add_inner(fun_result)
-
-                # Printing information about failures and non-equal functions.
-                if fun_result.kind in [Result.Kind.NOT_EQUAL,
-                                       Result.Kind.UNKNOWN,
-                                       Result.Kind.ERROR] or config.full_diff:
-                    if fun_result.kind == Result.Kind.NOT_EQUAL or \
-                       config.full_diff:
-                        # Create the output directory if needed
-                        if output_dir is not None:
-                            if not os.path.isdir(output_dir):
-                                os.mkdir(output_dir)
-                        # Create the group directory or print the group name
-                        # if needed
-                        if group_dir is not None:
-                            if not os.path.isdir(group_dir):
-                                os.mkdir(group_dir)
-                        elif group_name is not None and not group_printed:
-                            print("{}:".format(group_name))
-                            group_printed = True
-                        print_syntax_diff(
-                            snapshot_dir_old=args.snapshot_dir_old,
-                            snapshot_dir_new=args.snapshot_dir_new,
-                            fun=fun,
-                            fun_result=fun_result,
-                            fun_tag=old_fun_desc.tag,
-                            output_dir=group_dir if group_dir else output_dir,
-                            show_diff=config.show_diff,
-                            full_diff=config.full_diff,
-                            initial_indent=2 if (group_name is not None and
-                                                 group_dir is None) else 0)
-                    else:
-                        # Print the group name if needed
-                        if group_name is not None and not group_printed:
-                            print("{}:".format(group_name))
-                            group_printed = True
-                        print("{}: {}".format(fun, str(fun_result.kind)))
-
-            # Clean LLVM modules (allow GC to collect the occupied memory)
-            old_fun_desc.mod.clean_module()
-            new_fun_desc.mod.clean_module()
-            LlvmModule.clean_all()
-    # Create yaml output
-    if output_dir is not None and os.path.isdir(output_dir):
-        old_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_old), "")
-        new_dir_abs = os.path.join(os.path.abspath(args.snapshot_dir_new), "")
-        yaml_output = YamlOutput(snapshot_dir_old=old_dir_abs,
-                                 snapshot_dir_new=new_dir_abs, result=result)
-        yaml_output.save(output_dir=output_dir, file_name=YAML_FILE_NAME)
-    config.snapshot_first.finalize()
-    config.snapshot_second.finalize()
-
-    if output_dir is not None and os.path.isdir(output_dir):
-        print("Differences stored in {}/".format(output_dir))
-
-    if args.report_stat or args.extended_stat:
-        print("")
-        print("Statistics")
-        print("----------")
-        result.stop_time = default_timer()
-        result.report_stat(args.show_errors, args.extended_stat)
-    return 0
-
-
-def default_output_dir(src_snapshot, dest_snapshot):
-    """Name of the directory to put log files into."""
-    base_dirname = "diff-{}-{}".format(
-        os.path.basename(os.path.normpath(src_snapshot)),
-        os.path.basename(os.path.normpath(dest_snapshot)))
-    if os.path.isdir(base_dirname):
-        suffix = 0
-        dirname = base_dirname
-        while os.path.isdir(dirname):
-            dirname = "{}-{}".format(base_dirname, suffix)
-            suffix += 1
-        return dirname
-    return base_dirname
 
 
 def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
@@ -391,10 +192,10 @@ class Viewer:
 
     def _load_yaml(self):
         """Load yaml which describes results."""
-        yaml_path = os.path.join(self.compare_output_dir, YAML_FILE_NAME)
+        yaml_path = os.path.join(self.compare_output_dir, CMP_OUTPUT_FILE)
         if not os.path.exists(yaml_path):
             sys.stderr.write(
-                f"ERROR: compare output is missing file '{YAML_FILE_NAME}'\n")
+                f"ERROR: compare output is missing file '{CMP_OUTPUT_FILE}'\n")
             sys.exit(errno.EINVAL)
         with open(yaml_path, "r") as file:
             self.yaml_result = yaml.safe_load(file)
@@ -468,7 +269,7 @@ class Viewer:
         for name, definition in self.yaml_result["definitions"].items():
             self._prepare_file_and_diff(name, definition)
         # Save updated YAML to viewer directory.
-        self.viewer_yaml_path = os.path.join(self.data_dir, YAML_FILE_NAME)
+        self.viewer_yaml_path = os.path.join(self.data_dir, CMP_OUTPUT_FILE)
         with open(self.viewer_yaml_path, "w") as file:
             yaml.dump(self.yaml_result, file, sort_keys=False)
 

--- a/diffkemp/utils.py
+++ b/diffkemp/utils.py
@@ -4,6 +4,8 @@ import re
 import sys
 
 LLVM_FUNCTION_REGEX = re.compile(r"^define.*@(\w+)\(", flags=re.MULTILINE)
+# Name of YAML output file created by diffkemp compare command.
+CMP_OUTPUT_FILE = "diffkemp-out.yaml"
 
 
 def get_simpll_build_dir():

--- a/tests/testing_projects/.gitignore
+++ b/tests/testing_projects/.gitignore
@@ -3,3 +3,4 @@
 # Files created by the build command
 *.ll
 function_list
+*.so.llw


### PR DESCRIPTION
This PR focuses on refactoring of the compare function, for readability and maintainability purposes.

- Moving it to its own source file `compare.py`
- Splitting it into multiple helper functions

No functional changes are expected as logic was not changed.

### Open Question
While refactoring the compare function, I noticed that some functions, specifically `function_diff` and after refactoring `_print_information`, pass around a lot of variables. I was wondering if it would be beneficial to:

-  create a class, `CompareContext`, to group them together (`mod_first`, `mod_second`, `fun`, `glob_var`, `cache`, ...)
-  maybe, use some of the helper functions, as methods for the class (`_modules_to_cache`, `_set_output_dir`, ...)

This would require further refactoring of not only the `compare.py` file, but also the `function_diff` and other functions which would be affected. I would like an input of whether this would be beneficial for the readability.