### PR TITLE
Nix: update nixpkgs to 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712136707,
-        "narHash": "sha256-8mHY6d6aGnkDsr+zq1HWjEOCis/QN9WBSX6uQDSIFPY=",
+        "lastModified": 1757076073,
+        "narHash": "sha256-O0NKO6RUofEhvkpEW0kLB3jU2Vgt13+DU7hCiVEDFBY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d56ff08cf00686829f188d7fcc2f0ad4908c5bd",
+        "rev": "3f446bcc494b0cc9e9eaed2a58b7398341211ca2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Static analyser of semantic differences in large C projects";
 
-  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/release-23.11"; };
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/release-25.05"; };
 
   outputs = { self, nixpkgs, ... }:
     let


### PR DESCRIPTION
There are some issues with the cffi Python module on nixpkgs 23.11 so update to the latest stable channel (which we want to do regularly anyway).