### PR TITLE
Make SimpLL compilable with clang, test it in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         llvm: [12, 13, 14, 15, 16, 17, 18]
         env:
-          - CC: gcc-9
-            CXX: g++-9
+          - CC: gcc
+            CXX: g++
         asan: [OFF]
         regression-tests: [true]
 
@@ -37,8 +37,8 @@ jobs:
 
           - llvm: 18
             env:
-              CC: gcc-9
-              CXX: g++-9
+              CC: gcc
+              CXX: g++
             asan: ON
             regression-tests: false
 
@@ -89,10 +89,10 @@ jobs:
           mkdir -p ${{ github.workspace }}/build
 
       - name: Configure and Build
-        env: ${{ matrix.env }}
         run: >
           nix develop .#diffkemp-llvm${{ matrix.llvm }} --command bash -c
-          "cmake -B build ${{ github.workspace }} -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }} &&
+          "export CC=${{ matrix.env.CC }} CXX=${{ matrix.env.CXX }} &&
+           cmake -B build ${{ github.workspace }} -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }} &&
            ninja -C build"
 
       - name: Run SimpLL Unit Tests

--- a/diffkemp/simpll/CMakeLists.txt
+++ b/diffkemp/simpll/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 add_library(simpll-lib ${srcs} ${passes} ${library})
 target_include_directories(simpll-lib PRIVATE ${Z3_CXX_INCLUDE_DIRS})
-target_link_libraries(simpll-lib PRIVATE ${Z3_LIBRARIES})
+target_link_libraries(simpll-lib PRIVATE ${Z3_LIBRARIES} -lstdc++ -lgcc_s)
 target_compile_options(simpll-lib PRIVATE ${Z3_COMPONENT_CXX_FLAGS})
 add_executable(simpll SimpLL.cpp)
 set_target_properties(simpll PROPERTIES PREFIX "diffkemp-")


### PR DESCRIPTION
As noticed by @DanielKriz, we are testing in the CI if the project is compilable with `gcc` but also with `clang`, but when we migrated to using Nix, the CI is using only `gcc` even when `clang` is specified as the compiler in the CI job matrix environment variable.
<img width="1453" height="790" alt="Screenshot from 2025-09-16 16-30-36" src="https://github.com/user-attachments/assets/909add87-3510-4adb-99b7-4ef922d88d75" />

The problem is that the environment variables set in the CI are not passed down to the `nix develop` shell (it overwrites them), therefore, we must set them again in the shell.

This PR fixes issues to make the project compilable with *clang* and fixes the CI to also use  *clang*.

<img width="1453" height="896" alt="Screenshot from 2025-09-16 16-34-44" src="https://github.com/user-attachments/assets/1b3e8c21-c792-4997-818b-f0f333893fdb" />
