### PR TITLE
Logger: Enhance logging for SmtBlockComparator

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -1176,12 +1176,17 @@ int DifferentialFunctionComparator::cmpBasicBlocksFromInstructions(
                 LOG_UNINDENT();
             }
 
-            if (Res && config.Patterns.SequentialAluOps && !suppressSmt)
+            if (Res && config.Patterns.SequentialAluOps && !suppressSmt) {
+                LOG("Trying to use sequential-alu-ops pattern:\n");
+                LOG_INDENT();
                 try {
                     Res = SmtComparator->compare(InstL, InstR);
+                    LOG((Res == 0 ? "SUCCESS\n" : "FAILURE\n"));
                 } catch (const SmtException &err) {
-                    LOG(err.what());
+                    LOG("ERROR: " << err.what() << "\n");
                 }
+                LOG_UNINDENT();
+            }
 
             if (Res)
                 return Res;

--- a/diffkemp/simpll/Logger.h
+++ b/diffkemp/simpll/Logger.h
@@ -106,6 +106,10 @@
 #define LOGGER_BASE_LEVEL DEBUG_SIMPLL_VERBOSE
 #define LOGGER_FORCE_LEVEL DEBUG_SIMPLL_VERBOSE_EXTRA
 
+// Checks if given logger level is turned on
+#define IS_LOG_VERBOSE_ON() isCurrentDebugType(LOGGER_BASE_LEVEL)
+#define IS_LOG_VERBOSE_EXTRA_ON() isCurrentDebugType(LOGGER_FORCE_LEVEL)
+
 // Temporarily turns off the logger if it is turned on.
 #define LOG_OFF()                                                              \
     do {                                                                       \
@@ -119,7 +123,7 @@
 // If it is then nothing happens.
 #define LOG_OFF_FOR_NO_FORCE()                                                 \
     do {                                                                       \
-        if (!isCurrentDebugType(LOGGER_FORCE_LEVEL)) {                         \
+        if (!IS_LOG_VERBOSE_EXTRA_ON()) {                                      \
             LOG_OFF();                                                         \
         }                                                                      \
     } while (false)

--- a/diffkemp/simpll/SmtBlockComparator.cpp
+++ b/diffkemp/simpll/SmtBlockComparator.cpp
@@ -50,12 +50,15 @@ void SmtBlockComparator::findSnippetEnd(BasicBlock::const_iterator &InstL,
             // the snippets are found to be unequal since otherwise, wrong
             // inlining would be done.
             auto tryInlineBackup = fComp->ModComparator->tryInline;
+            LOG_OFF();
             if (fComp->cmpBasicBlocksFromInstructions(
                         BBL, BBR, InstL, InstR, true, true)
                 == 0) {
+                LOG_ON();
                 // Found a synchronization point
                 return;
             }
+            LOG_ON();
             fComp->ModComparator->tryInline = tryInlineBackup;
             fComp->sn_mapL = sn_mapL_backup;
             fComp->sn_mapR = sn_mapR_backup;
@@ -674,6 +677,17 @@ int SmtBlockComparator::compareSnippets(BasicBlock::const_iterator &StartL,
     }
 
     s.add(constructPostCondition(c, StartL, EndL, StartR, EndR));
+
+    LOG_VERBOSE_EXTRA("SMT formula:\n");
+    LOG_INDENT();
+    if (IS_LOG_VERBOSE_EXTRA_ON()) {
+        std::istringstream formulaStream(s.to_smt2());
+        std::string line;
+        while (std::getline(formulaStream, line)) {
+            LOG_VERBOSE_EXTRA(line << "\n");
+        }
+    }
+    LOG_UNINDENT();
 
     auto start = timeSinceEpochMillisec();
     switch (s.check()) {


### PR DESCRIPTION
Providing more logs for `SmtBlockComparator` (`sequential-alu-ops`) to make it easier to debug problems.

Based on level following things are logged:
- 1+: Start of using `sequential-alu-ops` pattern, success/failure/error of the pattern
- 3+: SMT formula used for instructions comparison

This PR also:
- disables logging when trying to find end of a snippet,
- creates macros for checking what type of debug level is on.

The levels at which the logs are produced are place for discussion.
 
---
# Examples of outputs
Follows snippets of outputs of the logger run using #411.

## Examples for https://github.com/diffkemp/diffkemp/commit/a7be53eef62fafa7edf0d08b618231acd26e90d0 problem

### SIMPLL_VERBOSITY=1
#### Before
```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.60 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
SMT solver ran out of time/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (568 ms)
[----------] 1 test from DFCSmtTest (568 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (568 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```
#### Now
```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.57 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
Trying to use sequential-alu-ops pattern 
  ERROR: SMT solver ran out of time
/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (527 ms)
[----------] 1 test from DFCSmtTest (527 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (527 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```

### SIMPLL_VERBOSITY=2
#### Before
```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.57 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
L instruction:   %3 = add i8 %2, 3
R instruction:   %4 = mul i8 %1, 3
L instruction:   %3 = add i8 %2, 3
R instruction:   %5 = add i8 %3, %4
  L value:   %2 = add i8 2, 0
  R value:   %3 = mul i8 %1, %2
L instruction:   %3 = add i8 %2, 3
R instruction:   ret i8 %5
L instruction:   %4 = mul i8 %1, %3
R instruction:   %3 = mul i8 %1, %2
  L value:   %3 = add i8 %2, 3
  R value:   %2 = add i8 2, 0
L instruction:   %4 = mul i8 %1, %3
R instruction:   %4 = mul i8 %1, 3
  L value:   %3 = add i8 %2, 3
  R value: i8 3
L instruction:   %4 = mul i8 %1, %3
R instruction:   %5 = add i8 %3, %4
L instruction:   %4 = mul i8 %1, %3
R instruction:   ret i8 %5
L instruction:   ret i8 %4
R instruction:   %3 = mul i8 %1, %2
L instruction:   ret i8 %4
R instruction:   %4 = mul i8 %1, 3
L instruction:   ret i8 %4
R instruction:   %5 = add i8 %3, %4
SMT solver ran out of time/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (527 ms)
[----------] 1 test from DFCSmtTest (527 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (527 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```
#### Now

```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.57 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
Trying to use sequential-alu-ops pattern 
  ERROR: SMT solver ran out of time
/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (528 ms)
[----------] 1 test from DFCSmtTest (528 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (528 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```

### SIMPLL_VERBOSITY=3
#### Before
```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.56 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
L instruction:   %1 = add i8 1, 0
R instruction:   %1 = add i8 1, 0
L instruction:   %2 = add i8 2, 0
R instruction:   %2 = add i8 2, 0
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
Trying to find possible relocation:
  L instruction:   %3 = add i8 %2, 3
  R instruction:   %4 = mul i8 %1, 3
  L instruction:   %3 = add i8 %2, 3
  R instruction:   %5 = add i8 %3, %4
    L value:   %2 = add i8 2, 0
    R value:   %3 = mul i8 %1, %2
  L instruction:   %3 = add i8 %2, 3
  R instruction:   ret i8 %5
  L instruction:   %4 = mul i8 %1, %3
  R instruction:   %3 = mul i8 %1, %2
    L value:   %3 = add i8 %2, 3
    R value:   %2 = add i8 2, 0
  L instruction:   ret i8 %4
  R instruction:   %3 = mul i8 %1, %2
  FAILURE: Possible relocation was NOT found
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %3 = add i8 %2, 3
R instruction:   %4 = mul i8 %1, 3
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %3 = add i8 %2, 3
R instruction:   %5 = add i8 %3, %4
  L value:   %2 = add i8 2, 0
  R value:   %3 = mul i8 %1, %2
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %3 = add i8 %2, 3
R instruction:   ret i8 %5
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %4 = mul i8 %1, %3
R instruction:   %3 = mul i8 %1, %2
  L value:   %3 = add i8 %2, 3
  R value:   %2 = add i8 2, 0
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %4 = mul i8 %1, %3
R instruction:   %4 = mul i8 %1, 3
  L value:   %3 = add i8 %2, 3
  R value: i8 3
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %4 = mul i8 %1, %3
R instruction:   %5 = add i8 %3, %4
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   %4 = mul i8 %1, %3
R instruction:   ret i8 %5
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   ret i8 %4
R instruction:   %3 = mul i8 %1, %2
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   ret i8 %4
R instruction:   %4 = mul i8 %1, 3
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   ret i8 %4
R instruction:   %5 = add i8 %3, %4
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
L instruction:   ret i8 %4
R instruction:   ret i8 %5
SMT solver ran out of time/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (527 ms)
[----------] 1 test from DFCSmtTest (527 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (527 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```
#### Now

```txt
59/84 Test #59: DFCSmtTest.SmtDistributive .............................................***Failed    0.64 sec
Note: Google Test filter = DFCSmtTest.SmtDistributive
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DFCSmtTest
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
L instruction:   %1 = add i8 1, 0
R instruction:   %1 = add i8 1, 0
L instruction:   %2 = add i8 2, 0
R instruction:   %2 = add i8 2, 0
L instruction:   %3 = add i8 %2, 3
R instruction:   %3 = mul i8 %1, %2
Scope for macro not found
Scope for macro not found
Scope for macro not found
Scope for macro not found
Trying to find possible relocation:
  L instruction:   %3 = add i8 %2, 3
  R instruction:   %4 = mul i8 %1, 3
  L instruction:   %3 = add i8 %2, 3
  R instruction:   %5 = add i8 %3, %4
    L value:   %2 = add i8 2, 0
    R value:   %3 = mul i8 %1, %2
  L instruction:   %3 = add i8 %2, 3
  R instruction:   ret i8 %5
  L instruction:   %4 = mul i8 %1, %3
  R instruction:   %3 = mul i8 %1, %2
    L value:   %3 = add i8 %2, 3
    R value:   %2 = add i8 2, 0
  L instruction:   ret i8 %4
  R instruction:   %3 = mul i8 %1, %2
  FAILURE: Possible relocation was NOT found
Trying to use sequential-alu-ops pattern 
  SMT formula:
    ; 
    (set-info :status unknown)
    (declare-fun r_var_0x5d7380 () (_ BitVec 8))
    (declare-fun l_var_0x5d4a80 () (_ BitVec 8))
    (declare-fun l_var_0x5cf3d0 () (_ BitVec 8))
    (declare-fun r_var_0x5d6cb0 () (_ BitVec 8))
    (declare-fun l_var_0x5a8060 () (_ BitVec 8))
    (declare-fun l_var_0x5d61c0 () (_ BitVec 8))
    (declare-fun r_var_0x5d7440 () (_ BitVec 8))
    (declare-fun r_var_0x5d7500 () (_ BitVec 8))
    (declare-fun r_var_0x5d75e0 () (_ BitVec 8))
    (assert
     (= l_var_0x5d4a80 r_var_0x5d7380))
    (assert
     (= l_var_0x5cf3d0 (bvadd l_var_0x5d4a80 (_ bv3 8))))
    (assert
     (= l_var_0x5a8060 r_var_0x5d6cb0))
    (assert
     (= l_var_0x5d61c0 (bvmul l_var_0x5a8060 l_var_0x5cf3d0)))
    (assert
     (= r_var_0x5d7440 (bvmul r_var_0x5d6cb0 r_var_0x5d7380)))
    (assert
     (= r_var_0x5d7500 (bvmul r_var_0x5d6cb0 (_ bv3 8))))
    (assert
     (= r_var_0x5d75e0 (bvadd r_var_0x5d7440 r_var_0x5d7500)))
    (assert
     (not (and true (= l_var_0x5d61c0 r_var_0x5d75e0))))
    (check-sat)
  ERROR: SMT solver ran out of time
/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1098: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: -1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (596 ms)
[----------] 1 test from DFCSmtTest (596 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (596 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] DFCSmtTest.SmtDistributive

 1 FAILED TEST
```

## Example for successful SMT comparison

```txt
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
Trying to use sequential-alu-ops pattern 
  SUCCESS
[       OK ] DFCSmtTest.SmtDistributive (2580 ms)
```

## Example for unsuccessful SMT compare
```
[ RUN      ] DFCSmtTest.SmtDistributive
Analysing debugging information...
Analysing debugging information...
Trying to find possible relocation:
  FAILURE: Possible relocation was NOT found
Trying to use sequential-alu-ops pattern 
  FAILURE
/home/lukas/diffkemp-org/diffkemp/tests/unit_tests/simpll/DFCLlvmIrTest.cpp:1099: Failure
Expected equality of these values:
  DiffComp->compare()
    Which is: 1
  0

[  FAILED  ] DFCSmtTest.SmtDistributive (24 ms)
```

